### PR TITLE
Add browser-assisted login helpers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,6 @@ RUN mkdir -p /app/db
 EXPOSE 5728
 EXPOSE 41942
 EXPOSE 41943
+EXPOSE 41944
 
 CMD ["bilipod", "--config=/app/config.yaml", "--db=/app/db/data.db"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,7 @@ RUN mkdir -p /app/data
 RUN mkdir -p /app/db
 
 EXPOSE 5728
+EXPOSE 41942
+EXPOSE 41943
 
 CMD ["bilipod", "--config=/app/config.yaml", "--db=/app/db/data.db"]

--- a/README.md
+++ b/README.md
@@ -50,12 +50,21 @@ English / [简体中文](./README_CN.md)
    pip install .
    ```
 
-4. **Obtain your Bilibili cookies:**
-   - Follow the instructions in the [bilibili-api documentation](https://nemo2011.github.io/bilibili-api/#/get-credential).
+4. **Obtain your Bilibili cookies or configure login:**
+   - Follow the instructions in the [bilibili-api documentation](https://nemo2011.github.io/bilibili-api/#/get-credential), or set `login.method` to `password`, `sms`, or `qrcode` in `config.yaml`.
+   - For Docker login, publish or reverse proxy ports `41942` (Geetest login), `41943` (Geetest verification), and `41944` (QR code login).
 
 5. **Configure `config.yaml`:**
    - Provide your Bilibili cookies.
    - Customize feed settings (output format, quality, filters, etc.).
+   - String values can reference environment variables with `$env{VAR_NAME}`:
+
+     ```yaml
+     login:
+       method: password
+       username: $env{BILIPOD_USERNAME}
+       password: $env{BILIPOD_PASSWORD}
+     ```
 
 6. **Create your podcast feed:**
    ```bash
@@ -86,6 +95,9 @@ English / [简体中文](./README_CN.md)
        -v $(pwd)/config.yaml:/app/config.yaml \
        -v $(pwd)/data:/app/data \
        -p 5728:5728 \
+       -p 41942:41942 \
+       -p 41943:41943 \
+       -p 41944:41944 \
        sunrisewestern/bilipod:latest
    ```
 
@@ -105,6 +117,9 @@ services:
       - ./data:/app/data
     ports:
       - "5728:5728"
+      - "41942:41942"
+      - "41943:41943"
+      - "41944:41944"
 ```
 
 1. **Run with Docker Compose**:
@@ -122,6 +137,23 @@ services:
    ```bash
    docker-compose down
    ```
+
+### Reverse Proxy Login Helpers
+
+If you expose Bilipod through path-based Nginx routes, set the public login helper URLs explicitly:
+
+```yaml
+login:
+  geetest_login_url: https://example.com/login
+  geetest_verify_url: https://example.com/verify
+  qrcode_url: https://example.com/qrcode
+```
+
+After Geetest completes and Bilibili sends an SMS code, open the same `/login/` or `/verify/` URL again to submit the SMS code from the browser.
+The hosted Bilipod page also polls `/auth/status` and shows a clickable login notification while authentication is waiting for action.
+If the hosted page is public, protect `/auth/status`, `/login/`, `/verify/`, and `/qrcode/` with Basic Auth or an IP allowlist at Nginx.
+
+An Nginx example is available at `docs/nginx_bilipod_example.conf`.
 
 
 ## Documentation

--- a/README_CN.md
+++ b/README_CN.md
@@ -53,14 +53,23 @@
    pip install .
    ```
 
-4. **获取你的 Bilibili cookies：**
+4. **获取你的 Bilibili cookies 或配置登录：**
 
-   - 按照[bilibili-api 文档](https://nemo2011.github.io/bilibili-api/#/get-credential)中的说明操作。
+   - 按照[bilibili-api 文档](https://nemo2011.github.io/bilibili-api/#/get-credential)中的说明操作，或在 `config.yaml` 中将 `login.method` 设置为 `password`、`sms` 或 `qrcode`。
+   - Docker 登录时，请发布或反向代理 `41942`（Geetest 登录）、`41943`（Geetest 验证）和 `41944`（二维码登录）。
 
 5. **配置 `config.yaml`：**
 
    - 提供你的 Bilibili cookies。
    - 自定义订阅源设置（输出格式、质量、过滤器等）。
+   - 字符串值可以用 `$env{VAR_NAME}` 引用环境变量：
+
+     ```yaml
+     login:
+       method: password
+       username: $env{BILIPOD_USERNAME}
+       password: $env{BILIPOD_PASSWORD}
+     ```
 
 6. **创建你的播客订阅源：**
 
@@ -92,6 +101,9 @@ Docker 镜像可在 Docker Hub 上找到，名称为 `sunrisewestern/bilipod`。
        -v $(pwd)/config.yaml:/app/config.yaml \
        -v $(pwd)/data:/app/data \
        -p 5728:5728 \
+       -p 41942:41942 \
+       -p 41943:41943 \
+       -p 41944:41944 \
        sunrisewestern/bilipod:latest
    ```
 
@@ -111,6 +123,9 @@ services:
       - ./data:/app/data
     ports:
       - "5728:5728"
+      - "41942:41942"
+      - "41943:41943"
+      - "41944:41944"
 ```
 
 1. **使用 Docker Compose 运行**：
@@ -128,6 +143,23 @@ services:
    ```bash
    docker-compose down
    ```
+
+### 反向代理登录辅助页面
+
+如果通过 Nginx 路径代理暴露 Bilipod，请显式设置公开访问的登录辅助页面 URL：
+
+```yaml
+login:
+  geetest_login_url: https://example.com/login
+  geetest_verify_url: https://example.com/verify
+  qrcode_url: https://example.com/qrcode
+```
+
+完成 Geetest 后，如果 Bilibili 发送了短信验证码，请再次打开相同的 `/login/` 或 `/verify/` URL，并在网页中提交短信验证码。
+Bilipod 主页面也会轮询 `/auth/status`，并在认证等待操作时显示可点击的登录提示。
+如果主页面公开访问，请在 Nginx 中用 Basic Auth 或 IP allowlist 保护 `/auth/status`、`/login/`、`/verify/` 和 `/qrcode/`。
+
+Nginx 示例见 `docs/nginx_bilipod_example.conf`。
 
 ## 文档
 

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -38,11 +38,38 @@ token:
   cookie_file_path: # optional, use this if you want to use exported Netscape cookies
 
 login:
-  # Optional. If you want to use bilibili account info (e.g. username, password, phone number) to login, you can set this field.
+  # Optional. Login method: password, sms, or qrcode. If unset, Bilipod chooses from the fields below or asks at startup.
+  method:
+
+  # Environment variables are supported in string values with $env{VAR_NAME}.
+  # Example: username: $env{BILIPOD_USERNAME}
+
+  # Password login.
   username:
   password:
+
+  # SMS login.
   phone_number:
   country_code: # default is +86
+
+  # Geetest CAPTCHA helper pages. Use fixed ports so Docker/reverse proxies can route them.
+  geetest_bind_address: "0.0.0.0"
+  geetest_login_port: 41942
+  geetest_verify_port: 41943
+  # Optional browser-facing URLs if these ports are reverse proxied.
+  # Set these explicitly when using path-based proxy routes.
+  # Example: https://example.com/login and https://example.com/verify
+  # These pages are also reused for SMS code input after Geetest completes.
+  # geetest_login_url:
+  # geetest_verify_url:
+
+  # QR code login helper page.
+  qrcode_bind_address: "0.0.0.0"
+  qrcode_port: 41944
+  # Optional browser-facing URL if this port is reverse proxied.
+  # Set this explicitly when using a path-based proxy route.
+  # Example: https://example.com/qrcode
+  # qrcode_url:
 
 feeds:
   xiaoyuehankehan:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
       - "5728:5728"
       - "41942:41942" # geetest login
       - "41943:41943" # geetest verify
+      - "41944:41944" # qr code login
     volumes:
       - ./config_docker.yaml:/app/config.yaml
       - ./data:/app/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
     container_name: bilipod
     ports:
       - "5728:5728"
+      - "41942:41942" # geetest login
+      - "41943:41943" # geetest verify
     volumes:
       - ./config_docker.yaml:/app/config.yaml
       - ./data:/app/data

--- a/docs/TO_DO.MD
+++ b/docs/TO_DO.MD
@@ -1,3 +1,3 @@
-1. allow login through pop-up qr code
+1. [x] allow login through pop-up qr code
 2. allow custumized format, e.g. audio:192K:HI_RES, video:4K:HDR
-3. improve asynchronous implementation
+3. [x] improve asynchronous implementation

--- a/docs/nginx_bilipod_example.conf
+++ b/docs/nginx_bilipod_example.conf
@@ -1,0 +1,114 @@
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
+# Optional: protect auth-only routes while leaving feeds public.
+# Create the password file first, then uncomment the include lines below:
+#   sudo htpasswd -c /etc/nginx/.htpasswd-bilipod-auth admin
+#   sudo tee /etc/nginx/snippets/bilipod_auth.conf >/dev/null <<'EOF'
+#   auth_basic "BiliPod login helpers";
+#   auth_basic_user_file /etc/nginx/.htpasswd-bilipod-auth;
+#   EOF
+
+server {
+  listen 80;
+  listen [::]:80;
+  server_name example.com;
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+}
+
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  server_name example.com;
+
+  access_log /var/log/nginx/example.com_access.log;
+  error_log /var/log/nginx/example.com_error.log;
+
+  client_max_body_size 50M;
+
+  location / {
+    proxy_pass http://127.0.0.1:5728;
+    proxy_redirect off;
+    proxy_buffering off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+  }
+
+  location = /auth/status {
+    # include /etc/nginx/snippets/bilipod_auth.conf;
+    proxy_pass http://127.0.0.1:5728;
+    proxy_redirect off;
+    proxy_buffering off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location = /login {
+    return 301 /login/;
+  }
+
+  location /login/ {
+    # include /etc/nginx/snippets/bilipod_auth.conf;
+    proxy_pass http://127.0.0.1:41942;
+    proxy_redirect off;
+    proxy_buffering off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+  }
+
+  location = /verify {
+    return 301 /verify/;
+  }
+
+  location /verify/ {
+    # include /etc/nginx/snippets/bilipod_auth.conf;
+    proxy_pass http://127.0.0.1:41943;
+    proxy_redirect off;
+    proxy_buffering off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+  }
+
+  location = /qrcode {
+    return 301 /qrcode/;
+  }
+
+  location /qrcode/ {
+    # include /etc/nginx/snippets/bilipod_auth.conf;
+    proxy_pass http://127.0.0.1:41944;
+    proxy_redirect off;
+    proxy_buffering off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+  }
+
+  ssl_certificate /etc/nginx/certs/example.com/fullchain.pem;
+  ssl_certificate_key /etc/nginx/certs/example.com/privkey.pem;
+
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_prefer_server_ciphers on;
+  ssl_ciphers "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256";
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "bilipod"
-version = "0.6.0"
+version = "0.8.0"
 description = "Make bilibili user or playlist into podcast"
 readme = "README.md"
 requires-python = ">=3.8"
 license = { file = "LICENSE" }
 dependencies = [
-  "bilibili-api-python @ git+https://github.com/Nemo2011/bilibili-api.git@dev",
+  "bilibili-api-python @ git+https://github.com/Nemo2011/bilibili-api.git@d400cd5291df826e1c7269b99a4e476afe764536",
   "feedgen==1.0.0",
   "loguru==0.7.2",
   "PyYAML>=6.0",

--- a/src/bilipod/executing/web_server.py
+++ b/src/bilipod/executing/web_server.py
@@ -1,12 +1,15 @@
 import http.server
+import json
 import mimetypes
 import socketserver
 import ssl
 from pathlib import Path
 from socketserver import ThreadingMixIn
+from urllib.parse import urlparse
 
 import jinja2
 
+from ..utils.auth_status import get_auth_status
 from ..utils.bp_log import Logger
 
 logger = Logger().get_logger()
@@ -31,7 +34,8 @@ def run_web_server(server_config, data_dir: Path):
             super().__init__(*args, directory=str(data_dir), **kwargs)
 
         def do_GET(self):
-            if self.path == "/" or self.path == "/index.html":
+            request_path = urlparse(self.path).path
+            if request_path == "/" or request_path == "/index.html":
                 try:
                     template = jinja_env.get_template("index.html")
                     # Construct the base URL based on configuration
@@ -49,7 +53,15 @@ def run_web_server(server_config, data_dir: Path):
                 except Exception as e:
                     logger.error(f"Error serving index.html: {e}")
                     self.send_error(500, "Error serving index.html")
-            elif self.path == "podcast.opml":
+            elif request_path == "/auth/status":
+                body = json.dumps(get_auth_status()).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-type", "application/json; charset=utf-8")
+                self.send_header("Cache-Control", "no-store")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            elif request_path == "/podcast.opml":
                 opml_path = data_dir / "podcast.opml"
                 logger.info(f"Serving OPML file: {opml_path}")
                 if opml_path.is_file():
@@ -66,9 +78,9 @@ def run_web_server(server_config, data_dir: Path):
                         self.send_error(500, "Error serving opml.xml")
                 else:
                     self.send_error(404, "podcast.opml not found")
-            elif self.path.endswith(".xml"):
+            elif request_path.endswith(".xml"):
                 # Serve other XML files directly from the data directory
-                xml_file_name = self.path.lstrip("/")
+                xml_file_name = request_path.lstrip("/")
                 xml_path = Path(data_dir) / xml_file_name
                 if xml_path.is_file():
                     try:
@@ -85,11 +97,11 @@ def run_web_server(server_config, data_dir: Path):
                 else:
                     logger.warning(f"XML file not found: {xml_path}")
                     self.send_error(404, f"{xml_file_name} not found")
-            elif self.path.startswith("/static"):
+            elif request_path.startswith("/static"):
                 static_file_path = (
                     Path(__file__).parent.parent.resolve()
                     / "web"
-                    / self.path.lstrip("/")
+                    / request_path.lstrip("/")
                 )
                 if static_file_path.is_file():
                     self.send_response(200)

--- a/src/bilipod/main.py
+++ b/src/bilipod/main.py
@@ -53,7 +53,20 @@ async def run_service(config: BiliPodConfig, db_path: str):
 
     logger = Logger().get_logger()
 
-    # lode and check credential
+    data_dir = Path(config.storage.data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    web_server_thread = threading.Thread(
+        target=run_web_server,
+        args=(
+            config.server,
+            data_dir,
+        ),
+        daemon=True,
+    )
+    web_server_thread.start()
+
+    # load and check credential
     credential = await get_credential(config=config)
 
     logger.info(BANNER)
@@ -73,20 +86,9 @@ async def run_service(config: BiliPodConfig, db_path: str):
     episode_tbl = db.table("episode")
 
     # media dir init
-    media_dir = Path(config.storage.data_dir) / "media"
+    media_dir = data_dir / "media"
     if not media_dir.exists():
         media_dir.mkdir(parents=True, exist_ok=True)
-
-    # web server
-    web_server_thread = threading.Thread(
-        target=run_web_server,
-        args=(
-            config.server,
-            config.storage.data_dir,
-        ),
-        daemon=True,
-    )
-    web_server_thread.start()
 
     # initialize pod and episodes
     await data_initialize(

--- a/src/bilipod/utils/auth_status.py
+++ b/src/bilipod/utils/auth_status.py
@@ -1,0 +1,63 @@
+import threading
+import time
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+
+@dataclass
+class AuthStatusSnapshot:
+    state: str = "idle"
+    message: str = ""
+    action_label: Optional[str] = None
+    action_url: Optional[str] = None
+    updated_at: float = 0.0
+
+
+class AuthStatus:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._snapshot = AuthStatusSnapshot()
+
+    def set(
+        self,
+        state: str,
+        message: str,
+        action_label: Optional[str] = None,
+        action_url: Optional[str] = None,
+    ) -> None:
+        with self._lock:
+            self._snapshot = AuthStatusSnapshot(
+                state=state,
+                message=message,
+                action_label=action_label,
+                action_url=action_url,
+                updated_at=time.time(),
+            )
+
+    def clear(self) -> None:
+        with self._lock:
+            self._snapshot = AuthStatusSnapshot(updated_at=time.time())
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            return asdict(self._snapshot)
+
+
+AUTH_STATUS = AuthStatus()
+
+
+def set_auth_status(
+    state: str,
+    message: str,
+    action_label: Optional[str] = None,
+    action_url: Optional[str] = None,
+) -> None:
+    AUTH_STATUS.set(state, message, action_label, action_url)
+
+
+def clear_auth_status() -> None:
+    AUTH_STATUS.clear()
+
+
+def get_auth_status() -> dict:
+    return AUTH_STATUS.snapshot()

--- a/src/bilipod/utils/biliuser.py
+++ b/src/bilipod/utils/biliuser.py
@@ -174,12 +174,14 @@ async def get_series_info(
 def get_episode_list(pod: Pod) -> List[Episode]:
     return [
         Episode(
-            **episodes_info,
-            format=pod.format,
-            quality=pod.quality,
-            data_dir=pod.data_dir,
-            base_url=pod.base_url,
-            endorse=pod.endorse,
+            **{
+                **episodes_info,
+                "format": pod.format,
+                "quality": pod.quality,
+                "data_dir": pod.data_dir,
+                "base_url": pod.base_url,
+                "endorse": pod.endorse,
+            }
         )
         for episodes_info in pod.episodes
     ]

--- a/src/bilipod/utils/config_parser.py
+++ b/src/bilipod/utils/config_parser.py
@@ -8,7 +8,7 @@ from .parse_netscape import parse_netscape_cookies
 
 @dataclass
 class ServerConfig:
-    port: int = 8080
+    port: int = 5728
     hostname: Optional[str] = None
     bind_address: str = "localhost"
     path: str = ""
@@ -96,7 +96,7 @@ class BiliPodConfig:
         # Parse and create ServerConfig
         server_data = config_data.get("server", {})
         server_config = ServerConfig(
-            port=server_data.get("port", 8080),
+            port=server_data.get("port", 5728),
             hostname=server_data.get("hostname"),
             bind_address=server_data.get("bind_address", "localhost"),
             path=server_data.get("path", ""),
@@ -114,18 +114,23 @@ class BiliPodConfig:
 
         # Parse and create TokenConfig
         token_data = config_data.get("token", {})
-        if token_data.get("cookie_file_path"):
-            token_data_update = parse_netscape_cookies(token_data["cookie_file_path"])
-            token_data.update(token_data_update)
+        if token_data is None:
+            token_config = None
+        else:
+            if token_data.get("cookie_file_path") is not None:
+                token_data_update = parse_netscape_cookies(
+                    token_data["cookie_file_path"]
+                )
+                token_data.update(token_data_update)
 
-        token_config = TokenConfig(
-            bili_jct=token_data["bili_jct"],
-            buvid3=token_data["buvid3"],
-            buvid4=token_data.get("buvid4", ""),
-            dedeuserid=token_data["dedeuserid"],
-            sessdata=token_data["sessdata"],
-            ac_time_value=token_data.get("ac_time_value", ""),
-        )
+            token_config = TokenConfig(
+                bili_jct=token_data["bili_jct"],
+                buvid3=token_data["buvid3"],
+                buvid4=token_data.get("buvid4", ""),
+                dedeuserid=token_data["dedeuserid"],
+                sessdata=token_data["sessdata"],
+                ac_time_value=token_data.get("ac_time_value", ""),
+            )
 
         # Parse and create login_config
         login_data = config_data.get("login", {})

--- a/src/bilipod/utils/config_parser.py
+++ b/src/bilipod/utils/config_parser.py
@@ -1,9 +1,35 @@
+import os
+import re
 from dataclasses import asdict, dataclass
-from typing import Dict, Literal, Optional, Sequence, Union
+from typing import Any, Dict, Literal, Optional, Sequence, Union
 
 import yaml
 
 from .parse_netscape import parse_netscape_cookies
+
+ENV_VAR_PATTERN = re.compile(r"\$env\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _has_config_value(value) -> bool:
+    return value is not None and str(value).strip() != ""
+
+
+def _optional_str(value) -> Optional[str]:
+    if not _has_config_value(value):
+        return None
+    return str(value)
+
+
+def _expand_env_values(value: Any) -> Any:
+    if isinstance(value, str):
+        return ENV_VAR_PATTERN.sub(
+            lambda match: os.environ.get(match.group(1), ""), value
+        )
+    if isinstance(value, dict):
+        return {key: _expand_env_values(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_expand_env_values(item) for item in value]
+    return value
 
 
 @dataclass
@@ -35,10 +61,19 @@ class TokenConfig:
 
 @dataclass
 class LoginConfig:
+    method: Optional[str] = None
     username: Optional[str] = None
     password: Optional[str] = None
     phone_number: Optional[str] = None
     country_code: Optional[str] = "+86"
+    geetest_bind_address: str = "0.0.0.0"
+    geetest_login_port: int = 41942
+    geetest_verify_port: int = 41943
+    geetest_login_url: Optional[str] = None
+    geetest_verify_url: Optional[str] = None
+    qrcode_bind_address: str = "0.0.0.0"
+    qrcode_port: int = 41944
+    qrcode_url: Optional[str] = None
 
 
 @dataclass
@@ -83,15 +118,15 @@ class LogConfig:
 class BiliPodConfig:
     server: ServerConfig
     storage: StorageConfig
-    token: TokenConfig
+    token: Optional[TokenConfig]
     login: LoginConfig
     feeds: Dict[str, FeedConfig]
-    log: LogConfig
+    log: Optional[LogConfig]
 
     @staticmethod
     def from_yaml(config_file: str) -> "BiliPodConfig":
         with open(config_file, "r") as file:
-            config_data = yaml.safe_load(file)
+            config_data = _expand_env_values(yaml.safe_load(file) or {})
 
         # Parse and create ServerConfig
         server_data = config_data.get("server", {})
@@ -113,32 +148,60 @@ class BiliPodConfig:
         )
 
         # Parse and create TokenConfig
-        token_data = config_data.get("token", {})
-        if token_data is None:
-            token_config = None
-        else:
-            if token_data.get("cookie_file_path") is not None:
+        token_data = config_data.get("token")
+        token_config = None
+        if token_data:
+            if _has_config_value(token_data.get("cookie_file_path")):
                 token_data_update = parse_netscape_cookies(
                     token_data["cookie_file_path"]
                 )
                 token_data.update(token_data_update)
 
-            token_config = TokenConfig(
-                bili_jct=token_data["bili_jct"],
-                buvid3=token_data["buvid3"],
-                buvid4=token_data.get("buvid4", ""),
-                dedeuserid=token_data["dedeuserid"],
-                sessdata=token_data["sessdata"],
-                ac_time_value=token_data.get("ac_time_value", ""),
+            required_token_fields = ("bili_jct", "buvid3", "dedeuserid", "sessdata")
+            has_any_token_field = any(
+                _has_config_value(token_data.get(field))
+                for field in required_token_fields
             )
 
+            if has_any_token_field:
+                missing_token_fields = [
+                    field
+                    for field in required_token_fields
+                    if not _has_config_value(token_data.get(field))
+                ]
+                if missing_token_fields:
+                    raise ValueError(
+                        "Token config is incomplete. Missing: "
+                        + ", ".join(missing_token_fields)
+                    )
+
+                token_config = TokenConfig(
+                    bili_jct=token_data["bili_jct"],
+                    buvid3=token_data["buvid3"],
+                    buvid4=token_data.get("buvid4", ""),
+                    dedeuserid=token_data["dedeuserid"],
+                    sessdata=token_data["sessdata"],
+                    ac_time_value=token_data.get("ac_time_value", ""),
+                )
+
         # Parse and create login_config
-        login_data = config_data.get("login", {})
+        login_data = config_data.get("login", {}) or {}
         login_config = LoginConfig(
-            username=login_data.get("username"),
-            password=login_data.get("password"),
-            phone_number=login_data.get("phone_number"),
-            country_code=login_data.get("country_code", "+86"),
+            method=_optional_str(login_data.get("method")),
+            username=_optional_str(login_data.get("username")),
+            password=_optional_str(login_data.get("password")),
+            phone_number=_optional_str(login_data.get("phone_number")),
+            country_code=_optional_str(login_data.get("country_code")) or "+86",
+            geetest_bind_address=str(
+                login_data.get("geetest_bind_address", "0.0.0.0")
+            ),
+            geetest_login_port=login_data.get("geetest_login_port", 41942),
+            geetest_verify_port=login_data.get("geetest_verify_port", 41943),
+            geetest_login_url=_optional_str(login_data.get("geetest_login_url")),
+            geetest_verify_url=_optional_str(login_data.get("geetest_verify_url")),
+            qrcode_bind_address=str(login_data.get("qrcode_bind_address", "0.0.0.0")),
+            qrcode_port=login_data.get("qrcode_port", 41944),
+            qrcode_url=_optional_str(login_data.get("qrcode_url")),
         )
 
         # Parse and create FeedConfig for each feed

--- a/src/bilipod/utils/login.py
+++ b/src/bilipod/utils/login.py
@@ -1,12 +1,35 @@
+import asyncio
 import sys
 from typing import Literal
 
-from bilibili_api import Credential, Geetest, GeetestType, login_v2, sync, user
+from bilibili_api import Credential, Geetest, GeetestType, login_v2, user
+from bilibili_api.exceptions import GeetestException
+from bilibili_api.utils.geetest import ServerThread
 
 from .bp_log import Logger
 from .config_parser import BiliPodConfig
 
 logger = Logger().get_logger()
+
+GEETEST_PORT_LOGIN = 41942
+GEETEST_PORT_VERIFY = 41943
+
+
+class FixedPortGeetest(Geetest):
+    def __init__(self, port: int = 0):
+        super().__init__()
+        self._port = port
+
+    def start_geetest_server(self) -> None:
+        """
+        开启本地极验验证码服务
+        """
+        if self.thread is not None:
+            raise GeetestException("验证码服务已创建。")
+        self.thread = ServerThread(self._geetest_urlhandler, "0.0.0.0", self._port)
+        self.thread.start()
+        while not self.thread.error and not self.thread.serving:
+            pass
 
 
 async def password_login(
@@ -16,12 +39,15 @@ async def password_login(
     phone_number=None,
     country_code="+86",
 ) -> Credential:
-    gee = Geetest()
+    gee = FixedPortGeetest(port=GEETEST_PORT_LOGIN)
     await gee.generate_test()
     gee.start_geetest_server()
-    print(gee.get_geetest_server_url())
+    url = gee.get_geetest_server_url()
+    print(f"Geetest Server started at: {url}")
+    print(f"If you are running locally, try: http://127.0.0.1:{GEETEST_PORT_LOGIN}/")
+    print(f"If you are running remotely, try: http://<YOUR_IP>:{GEETEST_PORT_LOGIN}/")
     while not gee.has_done():
-        pass
+        await asyncio.sleep(1)
     gee.close_geetest_server()
     print("result:", gee.get_result())
 
@@ -43,12 +69,15 @@ async def password_login(
 
     # Security verification
     if isinstance(cred, login_v2.LoginCheck):
-        gee = Geetest()
+        gee = FixedPortGeetest(port=GEETEST_PORT_VERIFY)
         await gee.generate_test(type_=GeetestType.VERIFY)
         gee.start_geetest_server()
-        print(gee.get_geetest_server_url())
+        url = gee.get_geetest_server_url()
+        print(f"Geetest Verification Server started at: {url}")
+        print(f"If you are running locally, try: http://127.0.0.1:{GEETEST_PORT_VERIFY}/")
+        print(f"If you are running remotely, try: http://<YOUR_IP>:{GEETEST_PORT_VERIFY}/")
         while not gee.has_done():
-            pass
+            await asyncio.sleep(1)
         gee.close_geetest_server()
         print("result:", gee.get_result())
         await cred.send_sms(gee)
@@ -60,12 +89,7 @@ async def password_login(
 
 
 async def get_credential(config: BiliPodConfig) -> Credential:
-    if (
-        config.token.bili_jct
-        and config.token.buvid3
-        and config.token.dedeuserid
-        and config.token.sessdata
-    ):
+    if config.token:
         if not config.token.ac_time_value:
             logger.warning("ac_time_value is not set. It may cause some issues.")
 

--- a/src/bilipod/utils/login.py
+++ b/src/bilipod/utils/login.py
@@ -1,35 +1,302 @@
 import asyncio
+import http.server
 import sys
-from typing import Literal
+import threading
+import time
+from getpass import getpass
+from html import escape
+from pathlib import Path
+from typing import Callable, Literal, Optional
+from urllib.parse import parse_qs, urlparse
 
 from bilibili_api import Credential, Geetest, GeetestType, login_v2, user
 from bilibili_api.exceptions import GeetestException
 from bilibili_api.utils.geetest import ServerThread
 
+from .auth_status import set_auth_status
 from .bp_log import Logger
-from .config_parser import BiliPodConfig
+from .config_parser import BiliPodConfig, LoginConfig
 
 logger = Logger().get_logger()
 
-GEETEST_PORT_LOGIN = 41942
-GEETEST_PORT_VERIFY = 41943
+QRCODE_LOGIN_TEMPLATE_PATH = (
+    Path(__file__).parent.parent / "web" / "static" / "qrcode_login.html"
+)
+SMS_CODE_TEMPLATE_PATH = (
+    Path(__file__).parent.parent / "web" / "static" / "sms_code.html"
+)
+SMS_STATUS_DISPLAY_SECONDS = 60
+
+LoginMethod = Literal["pwd", "sms", "qrcode"]
 
 
 class FixedPortGeetest(Geetest):
-    def __init__(self, port: int = 0):
+    def __init__(
+        self, port: int = 0, host: str = "0.0.0.0", path_prefix: str = ""
+    ):
         super().__init__()
+        self._host = host
         self._port = port
+        self._path_prefix = path_prefix
 
     def start_geetest_server(self) -> None:
         """
-        开启本地极验验证码服务
+        Start the local Geetest challenge server on a deterministic host and port.
         """
         if self.thread is not None:
-            raise GeetestException("验证码服务已创建。")
-        self.thread = ServerThread(self._geetest_urlhandler, "0.0.0.0", self._port)
+            raise GeetestException("Captcha server already exists.")
+
+        self.thread = ServerThread(self._geetest_urlhandler, self._host, self._port)
         self.thread.start()
         while not self.thread.error and not self.thread.serving:
-            pass
+            time.sleep(0.05)
+
+        if self.thread.error:
+            error = self.thread.error
+            self.thread = None
+            raise GeetestException(
+                f"Failed to start Geetest server on {self._host}:{self._port}: {error}"
+            )
+
+    def _geetest_urlhandler(self, url: str, content_type: str) -> str:
+        return super()._geetest_urlhandler(
+            _strip_path_prefix(url, self._path_prefix), content_type
+        )
+
+
+class _ReusableThreadingHTTPServer(http.server.ThreadingHTTPServer):
+    allow_reuse_address = True
+
+
+class QRCodeLoginServer:
+    def __init__(
+        self,
+        image_bytes: bytes,
+        bind_address: str,
+        port: int,
+        status_getter: Callable[[], str],
+        path_prefix: str = "",
+    ):
+        self._image_bytes = image_bytes
+        self._bind_address = bind_address
+        self._port = port
+        self._status_getter = status_getter
+        self._path_prefix = path_prefix
+        self._server: Optional[_ReusableThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        image_bytes = self._image_bytes
+        status_getter = self._status_getter
+        path_prefix = self._path_prefix
+        image_path = f"{path_prefix}/qrcode.png" if path_prefix else "/qrcode.png"
+        health_path = f"{path_prefix}/health" if path_prefix else "/health"
+        template_source = _load_qrcode_login_template()
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                request_path = _strip_path_prefix(self.path, path_prefix)
+                if request_path in ("/", "/index.html"):
+                    body = _render_qrcode_login_page(
+                        template_source=template_source,
+                        qrcode_src=image_path,
+                        health_src=health_path,
+                        status=status_getter(),
+                    )
+                    body_bytes = body.encode("utf-8")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/html; charset=utf-8")
+                    self.send_header("Content-Length", str(len(body_bytes)))
+                    self.end_headers()
+                    self.wfile.write(body_bytes)
+                elif request_path == "/qrcode.png":
+                    self.send_response(200)
+                    self.send_header("Content-Type", "image/png")
+                    self.send_header("Content-Length", str(len(image_bytes)))
+                    self.end_headers()
+                    self.wfile.write(image_bytes)
+                elif request_path == "/health":
+                    status = status_getter().encode("utf-8")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/plain; charset=utf-8")
+                    self.send_header("Content-Length", str(len(status)))
+                    self.end_headers()
+                    self.wfile.write(status)
+                else:
+                    self.send_error(404)
+
+            def log_message(self, format, *args):
+                logger.debug(f"[QR Login Server] {format % args}")
+
+        self._server = _ReusableThreadingHTTPServer(
+            (self._bind_address, self._port), Handler
+        )
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+    @property
+    def port(self) -> int:
+        if self._server is not None:
+            return self._server.server_port
+        return self._port
+
+
+class SMSCodeServer:
+    def __init__(
+        self,
+        bind_address: str,
+        port: int,
+        path_prefix: str = "",
+        title: str = "BiliPod SMS Verification",
+        message: str = "Enter the SMS code sent by Bilibili.",
+    ):
+        self._bind_address = bind_address
+        self._port = port
+        self._path_prefix = path_prefix
+        self._title = title
+        self._message = message
+        self._submitted = False
+        self._lock = threading.Lock()
+        self._server: Optional[_ReusableThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+        self._code: Optional[str] = None
+        self._code_ready = threading.Event()
+
+    def start(self) -> None:
+        path_prefix = self._path_prefix
+        form_action = f"{path_prefix}/" if path_prefix else "/"
+        health_path = f"{path_prefix}/health" if path_prefix else "/health"
+        template_source = _load_sms_code_template()
+        sms_server = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                request_path = _strip_path_prefix(self.path, path_prefix)
+                if request_path in ("/", "/index.html"):
+                    message, submitted = sms_server.get_status()
+                    self._send_html(
+                        _render_sms_code_page(
+                            template_source=template_source,
+                            title=sms_server._title,
+                            message=message,
+                            form_action=form_action,
+                            health_src=health_path,
+                            submitted=submitted,
+                        )
+                    )
+                elif request_path == "/health":
+                    message, _ = sms_server.get_status()
+                    self._send_text(message)
+                else:
+                    self.send_error(404)
+
+            def do_POST(self):
+                request_path = _strip_path_prefix(self.path, path_prefix)
+                if request_path not in ("/", "/index.html"):
+                    self.send_error(404)
+                    return
+
+                content_length = int(self.headers.get("Content-Length", "0"))
+                raw_body = self.rfile.read(content_length).decode("utf-8")
+                code = parse_qs(raw_body).get("code", [""])[0].strip()
+                if not code:
+                    self._send_html(
+                        _render_sms_code_page(
+                            template_source=template_source,
+                            title=sms_server._title,
+                            message="Please enter the SMS code.",
+                            form_action=form_action,
+                            health_src=health_path,
+                        ),
+                        status=400,
+                    )
+                    return
+
+                sms_server._code = code
+                sms_server.set_status(
+                    "SMS code received. Verifying with Bilibili.", submitted=True
+                )
+                sms_server._code_ready.set()
+                self._send_html(
+                    _render_sms_code_page(
+                        template_source=template_source,
+                        title=sms_server._title,
+                        message=sms_server.get_status()[0],
+                        form_action=form_action,
+                        health_src=health_path,
+                        submitted=True,
+                    )
+                )
+
+            def _send_html(self, body: str, status: int = 200):
+                body_bytes = body.encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body_bytes)))
+                self.end_headers()
+                self.wfile.write(body_bytes)
+
+            def _send_text(self, body: str):
+                body_bytes = body.encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Content-Length", str(len(body_bytes)))
+                self.end_headers()
+                self.wfile.write(body_bytes)
+
+            def log_message(self, format, *args):
+                logger.debug(f"[SMS Code Server] {format % args}")
+
+        self._server = _ReusableThreadingHTTPServer(
+            (self._bind_address, self._port), Handler
+        )
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def get_status(self) -> tuple[str, bool]:
+        with self._lock:
+            return self._message, self._submitted
+
+    def set_status(self, message: str, submitted: Optional[bool] = None) -> None:
+        with self._lock:
+            self._message = message
+            if submitted is not None:
+                self._submitted = submitted
+
+    async def wait_for_code(self) -> str:
+        while not self._code_ready.is_set():
+            await asyncio.sleep(0.5)
+        if self._code is None:
+            raise RuntimeError("SMS code was not captured.")
+        return self._code
+
+    @property
+    def has_code(self) -> bool:
+        return self._code_ready.is_set()
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+    @property
+    def port(self) -> int:
+        if self._server is not None:
+            return self._server.server_port
+        return self._port
 
 
 async def password_login(
@@ -38,54 +305,160 @@ async def password_login(
     password=None,
     phone_number=None,
     country_code="+86",
+    login_config: Optional[LoginConfig] = None,
 ) -> Credential:
-    gee = FixedPortGeetest(port=GEETEST_PORT_LOGIN)
-    await gee.generate_test()
-    gee.start_geetest_server()
-    url = gee.get_geetest_server_url()
-    print(f"Geetest Server started at: {url}")
-    print(f"If you are running locally, try: http://127.0.0.1:{GEETEST_PORT_LOGIN}/")
-    print(f"If you are running remotely, try: http://<YOUR_IP>:{GEETEST_PORT_LOGIN}/")
-    while not gee.has_done():
-        await asyncio.sleep(1)
-    gee.close_geetest_server()
-    print("result:", gee.get_result())
+    login_config = login_config or LoginConfig()
+    gee = await _complete_geetest_challenge(
+        type_=GeetestType.LOGIN,
+        bind_address=login_config.geetest_bind_address,
+        port=login_config.geetest_login_port,
+        public_url=login_config.geetest_login_url,
+        label="login",
+    )
 
-    # Password login
     if choice == "pwd":
+        username = username or input("Username: ")
+        password = password if password is not None else getpass("Password: ")
         cred = await login_v2.login_with_password(
             username=username, password=password, geetest=gee
         )
-
-    # SMS login
-    if choice == "sms":
+    elif choice == "sms":
+        phone_number = phone_number or input("Phone number: ")
+        country_code = country_code or input("Country code (default +86): ") or "+86"
         phone = login_v2.PhoneNumber(phone_number, country_code)
         captcha_id = await login_v2.send_sms(phonenumber=phone, geetest=gee)
-        print("captcha_id:", captcha_id)
-        code = input("code: ")
-        cred = await login_v2.login_with_sms(
-            phonenumber=phone, code=code, captcha_id=captcha_id
+        logger.info("SMS code sent.")
+        sms_server = _start_sms_code_prompt(
+            bind_address=login_config.geetest_bind_address,
+            port=login_config.geetest_login_port,
+            public_url=login_config.geetest_login_url,
+            label="SMS login",
         )
+        keep_sms_server = False
+        try:
+            code = await sms_server.wait_for_code()
+            logger.info("SMS login code received from web page.")
+            sms_server.set_status("Verifying SMS code with Bilibili.", submitted=True)
+            set_auth_status("working", "Verifying SMS code with Bilibili.")
+            cred = await login_v2.login_with_sms(
+                phonenumber=phone, code=code, captcha_id=captcha_id
+            )
+            _finish_sms_code_prompt(
+                sms_server, "SMS login successful. You can close this page."
+            )
+            keep_sms_server = True
+        except Exception:
+            if sms_server.has_code:
+                _finish_sms_code_prompt(
+                    sms_server,
+                    "SMS login failed. Check Bilipod logs for details.",
+                    state="error",
+                )
+                keep_sms_server = True
+            raise
+        finally:
+            if not keep_sms_server:
+                sms_server.stop()
+    else:
+        raise ValueError("Invalid login method. Use 'pwd' or 'sms'.")
 
-    # Security verification
     if isinstance(cred, login_v2.LoginCheck):
-        gee = FixedPortGeetest(port=GEETEST_PORT_VERIFY)
-        await gee.generate_test(type_=GeetestType.VERIFY)
-        gee.start_geetest_server()
-        url = gee.get_geetest_server_url()
-        print(f"Geetest Verification Server started at: {url}")
-        print(f"If you are running locally, try: http://127.0.0.1:{GEETEST_PORT_VERIFY}/")
-        print(f"If you are running remotely, try: http://<YOUR_IP>:{GEETEST_PORT_VERIFY}/")
-        while not gee.has_done():
-            await asyncio.sleep(1)
-        gee.close_geetest_server()
-        print("result:", gee.get_result())
-        await cred.send_sms(gee)
-        code = input("code:")
-        cred = await cred.complete_check(code)
+        verify_gee = await _complete_geetest_challenge(
+            type_=GeetestType.VERIFY,
+            bind_address=login_config.geetest_bind_address,
+            port=login_config.geetest_verify_port,
+            public_url=login_config.geetest_verify_url,
+            label="security verification",
+        )
+        await cred.send_sms(verify_gee)
+        logger.info("Security verification SMS code sent.")
+        sms_server = _start_sms_code_prompt(
+            bind_address=login_config.geetest_bind_address,
+            port=login_config.geetest_verify_port,
+            public_url=login_config.geetest_verify_url,
+            label="security verification",
+        )
+        keep_sms_server = False
+        try:
+            code = await sms_server.wait_for_code()
+            logger.info("Security verification SMS code received from web page.")
+            sms_server.set_status("Verifying SMS code with Bilibili.", submitted=True)
+            set_auth_status("working", "Verifying SMS code with Bilibili.")
+            cred = await cred.complete_check(code)
+            _finish_sms_code_prompt(
+                sms_server,
+                "Security verification successful. You can close this page.",
+            )
+            keep_sms_server = True
+        except Exception:
+            if sms_server.has_code:
+                _finish_sms_code_prompt(
+                    sms_server,
+                    "Security verification failed. Check Bilipod logs for details.",
+                    state="error",
+                )
+                keep_sms_server = True
+            raise
+        finally:
+            if not keep_sms_server:
+                sms_server.stop()
 
-    print("cookies:", cred.get_cookies())
     return cred
+
+
+async def qrcode_login(login_config: Optional[LoginConfig] = None) -> Credential:
+    login_config = login_config or LoginConfig()
+    qr_login = login_v2.QrCodeLogin()
+    await qr_login.generate_qrcode()
+
+    status = {"message": "Scan this QR code with the Bilibili app."}
+    qr_server = QRCodeLoginServer(
+        image_bytes=qr_login.get_qrcode_picture().content,
+        bind_address=login_config.qrcode_bind_address,
+        port=login_config.qrcode_port,
+        status_getter=lambda: status["message"],
+        path_prefix=_path_prefix_from_url(login_config.qrcode_url),
+    )
+
+    try:
+        qr_server.start()
+        public_url = _format_public_url(
+            login_config.qrcode_url,
+            login_config.qrcode_bind_address,
+            qr_server.port,
+        )
+        _announce_auth_page("QR code login", public_url)
+        print(qr_login.get_qrcode_terminal())
+
+        last_event = None
+        while True:
+            event = await qr_login.check_state()
+            status["message"] = _qrcode_status_text(event)
+            if event != last_event:
+                logger.info(status["message"])
+                set_auth_status(
+                    state="action_required",
+                    message=status["message"],
+                    action_label="Open QR code login",
+                    action_url=public_url,
+                )
+                last_event = event
+
+            if event == login_v2.QrCodeLoginEvents.DONE:
+                set_auth_status("complete", "QR code login complete.")
+                return qr_login.get_credential()
+            if event == login_v2.QrCodeLoginEvents.TIMEOUT:
+                set_auth_status(
+                    "error",
+                    "QR code expired. Restart Bilipod to generate a new code.",
+                )
+                raise RuntimeError(
+                    "QR code login timed out. Restart Bilipod to generate a new code."
+                )
+
+            await asyncio.sleep(3)
+    finally:
+        qr_server.stop()
 
 
 async def get_credential(config: BiliPodConfig) -> Credential:
@@ -101,7 +474,6 @@ async def get_credential(config: BiliPodConfig) -> Credential:
             sessdata=config.token.sessdata,
             ac_time_value=config.token.ac_time_value,
         )
-        # check valid
         validation = await credential.check_valid()
         if not validation:
             logger.error(
@@ -109,39 +481,31 @@ async def get_credential(config: BiliPodConfig) -> Credential:
             )
             sys.exit()
     else:
-        if config.login.username and config.login.password:
-            # Password login
+        try:
+            method = _resolve_login_method(config.login)
+        except ValueError as e:
+            logger.error(str(e))
+            sys.exit()
+
+        if method == "pwd":
             credential = await password_login(
                 choice="pwd",
                 username=config.login.username,
                 password=config.login.password,
+                login_config=config.login,
             )
-        elif config.login.phone_number:
-            # SMS login
+        elif method == "sms":
             credential = await password_login(
                 choice="sms",
                 phone_number=config.login.phone_number,
                 country_code=config.login.country_code,
+                login_config=config.login,
             )
+        elif method == "qrcode":
+            credential = await qrcode_login(login_config=config.login)
         else:
-            choice = input("Please choose login method (pwd/sms): ")
-            if choice == "pwd":
-                username = input("Username: ")
-                password = input("Password: ")
-                credential = await password_login(
-                    choice="pwd", username=username, password=password
-                )
-            elif choice == "sms":
-                phone_number = input("Phone number: ")
-                country_code = input("Country code (default +86): ") or "+86"
-                credential = await password_login(
-                    choice="sms",
-                    phone_number=phone_number,
-                    country_code=country_code,
-                )
-            else:
-                logger.error("Invalid choice. Please choose either 'pwd' or 'sms'.")
-                sys.exit()
+            logger.error("Invalid login method. Please choose pwd, sms, or qrcode.")
+            sys.exit()
 
         logger.debug(
             f"""
@@ -155,6 +519,7 @@ async def get_credential(config: BiliPodConfig) -> Credential:
 
     user_info = await user.get_self_info(credential)
     logger.info(f"Welcome, {user_info['name']}!")
+    set_auth_status("complete", "Login complete.")
 
     return credential
 
@@ -176,3 +541,201 @@ async def update_credential(credential: Credential):
 
     else:
         logger.debug("No need to update token")
+
+
+async def _complete_geetest_challenge(
+    type_: GeetestType,
+    bind_address: str,
+    port: int,
+    public_url: Optional[str],
+    label: str,
+) -> Geetest:
+    gee = FixedPortGeetest(
+        port=port, host=bind_address, path_prefix=_path_prefix_from_url(public_url)
+    )
+    await gee.generate_test(type_=type_)
+    try:
+        gee.start_geetest_server()
+        actual_port = gee.thread.port if gee.thread is not None else port
+        display_url = _format_public_url(public_url, bind_address, actual_port)
+        _announce_auth_page(f"Geetest {label}", display_url)
+        while not gee.has_done():
+            await asyncio.sleep(1)
+        logger.debug(f"Geetest {label} result: {gee.get_result()}")
+        set_auth_status(
+            "working",
+            f"Geetest {label} complete. Continuing login.",
+        )
+    except Exception:
+        set_auth_status(
+            "error",
+            f"Geetest {label} failed. Check Bilipod logs for details.",
+        )
+        raise
+    finally:
+        if gee.thread is not None:
+            gee.close_geetest_server()
+
+    return gee
+
+
+def _start_sms_code_prompt(
+    bind_address: str,
+    port: int,
+    public_url: Optional[str],
+    label: str,
+) -> SMSCodeServer:
+    sms_server = SMSCodeServer(
+        bind_address=bind_address,
+        port=port,
+        path_prefix=_path_prefix_from_url(public_url),
+        title=f"BiliPod {label.title()}",
+    )
+    sms_server.start()
+    actual_port = sms_server.port
+    display_url = _format_public_url(public_url, bind_address, actual_port)
+    _announce_auth_page(f"{label.title()} SMS code", display_url)
+    return sms_server
+
+
+def _finish_sms_code_prompt(
+    sms_server: SMSCodeServer, message: str, state: str = "complete"
+) -> None:
+    sms_server.set_status(message, submitted=True)
+    set_auth_status(state, message)
+    stop_timer = threading.Timer(SMS_STATUS_DISPLAY_SECONDS, sms_server.stop)
+    stop_timer.daemon = True
+    stop_timer.start()
+
+
+def _resolve_login_method(login_config: LoginConfig) -> LoginMethod:
+    configured_method = _normalize_login_method(login_config.method)
+    if configured_method:
+        return configured_method
+    if login_config.username and login_config.password:
+        return "pwd"
+    if login_config.phone_number:
+        return "sms"
+
+    choice = input("Please choose login method (pwd/sms/qrcode): ")
+    return _normalize_login_method(choice) or "qrcode"
+
+
+def _normalize_login_method(method: Optional[str]) -> Optional[LoginMethod]:
+    if method is None:
+        return None
+
+    normalized = method.strip().lower()
+    if not normalized:
+        return None
+
+    if normalized in ("pwd", "password", "username_password"):
+        return "pwd"
+    if normalized in ("sms", "phone", "phone_number"):
+        return "sms"
+    if normalized in ("qr", "qrcode", "qr_code"):
+        return "qrcode"
+
+    raise ValueError("Invalid login method. Use pwd, sms, or qrcode.")
+
+
+def _format_public_url(
+    configured_url: Optional[str], bind_address: str, port: int
+) -> str:
+    if configured_url:
+        return _ensure_trailing_slash(configured_url)
+
+    return f"http://{_public_host(bind_address)}:{port}/"
+
+
+def _ensure_trailing_slash(url: str) -> str:
+    return url if url.endswith("/") else f"{url}/"
+
+
+def _announce_auth_page(label: str, url: str) -> None:
+    logger.info(f"{label} page: {url}")
+    logger.info("Open the page in a browser and finish the login challenge there.")
+    set_auth_status(
+        state="action_required",
+        message=f"{label} required.",
+        action_label=f"Open {label}",
+        action_url=url,
+    )
+
+
+def _qrcode_status_text(event) -> str:
+    if event == login_v2.QrCodeLoginEvents.SCAN:
+        return "Waiting for scan in the Bilibili app."
+    if event == login_v2.QrCodeLoginEvents.CONF:
+        return "QR code scanned. Confirm login in the Bilibili app."
+    if event == login_v2.QrCodeLoginEvents.TIMEOUT:
+        return "QR code expired. Restart Bilipod to generate a new code."
+    if event == login_v2.QrCodeLoginEvents.DONE:
+        return "QR code login complete."
+    return f"QR code login status: {event}"
+
+
+def _public_host(host: str) -> str:
+    if host in ("0.0.0.0", "::"):
+        return "127.0.0.1"
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
+def _load_qrcode_login_template() -> str:
+    return QRCODE_LOGIN_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+
+def _load_sms_code_template() -> str:
+    return SMS_CODE_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+
+def _render_qrcode_login_page(
+    template_source: str, qrcode_src: str, status: str, health_src: str = "/health"
+) -> str:
+    return (
+        template_source.replace("{{ qrcode_src }}", escape(qrcode_src, quote=True))
+        .replace("{{ health_src }}", escape(health_src, quote=True))
+        .replace("{{ status }}", escape(status))
+    )
+
+
+def _render_sms_code_page(
+    template_source: str,
+    title: str,
+    message: str,
+    form_action: str,
+    health_src: str = "/health",
+    submitted: bool = False,
+) -> str:
+    submit_button_attr = "disabled" if submitted else ""
+    return (
+        template_source.replace("{{ title }}", escape(title))
+        .replace("{{ message }}", escape(message))
+        .replace("{{ form_action }}", escape(form_action, quote=True))
+        .replace("{{ health_src }}", escape(health_src, quote=True))
+        .replace("{{ submit_button_attr }}", submit_button_attr)
+    )
+
+
+def _path_prefix_from_url(url: Optional[str]) -> str:
+    if not url:
+        return ""
+    return _normalize_path_prefix(urlparse(url).path)
+
+
+def _normalize_path_prefix(path: str) -> str:
+    if not path or path == "/":
+        return ""
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return path.rstrip("/")
+
+
+def _strip_path_prefix(path: str, path_prefix: str) -> str:
+    path = path.split("?", 1)[0]
+    path_prefix = _normalize_path_prefix(path_prefix)
+    if path_prefix and (path == path_prefix or path.startswith(f"{path_prefix}/")):
+        return path[len(path_prefix) :] or "/"
+    return path

--- a/src/bilipod/web/static/index.html
+++ b/src/bilipod/web/static/index.html
@@ -318,6 +318,17 @@
       border-radius: 12px;
     }
 
+    .auth-status-banner {
+      border-radius: 8px;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .auth-status-banner .btn {
+      white-space: nowrap;
+    }
+
     /* Feed list styling */
     .feed-list-item {
       cursor: pointer;
@@ -364,6 +375,16 @@
       </div>
     </div>
   </nav>
+
+  <div class="container mt-3">
+    <div id="auth-status-banner" class="alert auth-status-banner d-none" role="status">
+      <div>
+        <i id="auth-status-icon" class="bi bi-info-circle me-2"></i>
+        <span id="auth-status-message"></span>
+      </div>
+      <a id="auth-status-action" class="btn btn-sm d-none" target="_blank" rel="noopener"></a>
+    </div>
+  </div>
 
   <!-- Main Content -->
   <div class="container mt-4">
@@ -677,6 +698,59 @@
     let allFeeds = []; // New global variable to store feed data
     let currentFilterFeedUrl = null; // To keep track of the currently selected feed
 
+    async function loadAuthStatus() {
+      try {
+        const response = await fetch('auth/status', { cache: 'no-store' });
+        if (!response.ok) {
+          return;
+        }
+        renderAuthStatus(await response.json());
+      } catch (error) {
+        console.error('Error loading auth status:', error);
+      }
+    }
+
+    function renderAuthStatus(status) {
+      const banner = document.getElementById('auth-status-banner');
+      const icon = document.getElementById('auth-status-icon');
+      const message = document.getElementById('auth-status-message');
+      const action = document.getElementById('auth-status-action');
+
+      if (!status || status.state === 'idle' || !status.message) {
+        banner.className = 'alert auth-status-banner d-none';
+        action.classList.add('d-none');
+        return;
+      }
+
+      const stateClasses = {
+        action_required: ['alert-warning', 'bi-box-arrow-up-right', 'btn-warning'],
+        working: ['alert-info', 'bi-hourglass-split', 'btn-info'],
+        complete: ['alert-success', 'bi-check-circle', 'btn-success'],
+        error: ['alert-danger', 'bi-exclamation-triangle', 'btn-danger']
+      };
+      const [alertClass, iconClass, buttonClass] =
+        stateClasses[status.state] || stateClasses.working;
+
+      banner.className = `alert auth-status-banner d-flex ${alertClass}`;
+      icon.className = `bi ${iconClass} me-2`;
+      message.textContent = status.message;
+
+      if (status.action_url) {
+        action.href = status.action_url;
+        action.textContent = status.action_label || 'Open';
+        action.className = `btn btn-sm ${buttonClass}`;
+      } else {
+        action.removeAttribute('href');
+        action.textContent = '';
+        action.className = 'btn btn-sm d-none';
+      }
+    }
+
+    function startAuthStatusPolling() {
+      loadAuthStatus();
+      window.setInterval(loadAuthStatus, 2000);
+    }
+
     /**
      * Loads episodes and displays them in the UI
      */
@@ -938,6 +1012,7 @@
 
     // Load episodes when page loads
     document.addEventListener('DOMContentLoaded', function () {
+      startAuthStatusPolling();
       loadEpisodes();
     });
   </script>

--- a/src/bilipod/web/static/qrcode_login.html
+++ b/src/bilipod/web/static/qrcode_login.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BiliPod QR Login</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #f6f7f9;
+      color: #1f2933;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    main {
+      width: min(92vw, 420px);
+      text-align: center;
+    }
+
+    img {
+      width: min(76vw, 280px);
+      height: auto;
+      background: #fff;
+      border: 1px solid #d7dce2;
+      border-radius: 8px;
+      padding: 16px;
+    }
+
+    p {
+      margin: 16px 0 0;
+      font-size: 16px;
+      line-height: 1.4;
+    }
+  </style>
+</head>
+
+<body>
+  <main>
+    <img src="{{ qrcode_src }}" alt="Bilibili login QR code">
+    <p id="login-status" data-health-src="{{ health_src }}">{{ status }}</p>
+  </main>
+  <script>
+    const statusElement = document.getElementById("login-status");
+    const healthSrc = statusElement ? statusElement.dataset.healthSrc : "";
+
+    async function refreshStatus() {
+      if (!healthSrc || !statusElement) {
+        return;
+      }
+
+      try {
+        const response = await fetch(healthSrc, { cache: "no-store" });
+        if (response.ok) {
+          statusElement.textContent = await response.text();
+        }
+      } catch {
+        // Keep the current status visible if the helper server is shutting down.
+      }
+    }
+
+    refreshStatus();
+    window.setInterval(refreshStatus, 3000);
+  </script>
+</body>
+
+</html>

--- a/src/bilipod/web/static/sms_code.html
+++ b/src/bilipod/web/static/sms_code.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ title }}</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #f6f7f9;
+      color: #1f2933;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    main {
+      width: min(92vw, 420px);
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: 24px;
+      line-height: 1.2;
+    }
+
+    p {
+      margin: 0 0 18px;
+      font-size: 16px;
+      line-height: 1.4;
+    }
+
+    form {
+      display: grid;
+      gap: 12px;
+    }
+
+    input {
+      box-sizing: border-box;
+      width: 100%;
+      border: 1px solid #b8c0cc;
+      border-radius: 8px;
+      padding: 12px 14px;
+      font-size: 18px;
+      letter-spacing: 0;
+      background: #fff;
+      color: #111827;
+    }
+
+    button {
+      border: 0;
+      border-radius: 8px;
+      padding: 12px 14px;
+      font-size: 16px;
+      font-weight: 600;
+      color: #fff;
+      background: #2563eb;
+      cursor: pointer;
+    }
+
+    input:disabled {
+      background: #eef1f5;
+      color: #6b7280;
+    }
+
+    button:disabled {
+      background: #94a3b8;
+      cursor: default;
+    }
+  </style>
+</head>
+
+<body>
+  <main>
+    <h1>{{ title }}</h1>
+    <p id="sms-status" data-health-src="{{ health_src }}" aria-live="polite">
+      {{ message }}
+    </p>
+    <form method="post" action="{{ form_action }}">
+      <input
+        name="code"
+        inputmode="numeric"
+        autocomplete="one-time-code"
+        autofocus
+        required
+      >
+      <button type="submit" {{ submit_button_attr }}>Submit</button>
+    </form>
+  </main>
+  <script>
+    const statusElement = document.getElementById("sms-status");
+    const healthSrc = statusElement ? statusElement.dataset.healthSrc : "";
+    const form = document.querySelector("form");
+    const codeInput = document.querySelector("input[name='code']");
+    const submitButton = document.querySelector("button[type='submit']");
+
+    if (submitButton && submitButton.disabled && codeInput) {
+      codeInput.disabled = true;
+    }
+
+    if (form && submitButton) {
+      form.addEventListener("submit", () => {
+        submitButton.disabled = true;
+      });
+    }
+
+    async function refreshStatus() {
+      if (!healthSrc || !statusElement) {
+        return;
+      }
+
+      try {
+        const response = await fetch(healthSrc, { cache: "no-store" });
+        if (response.ok) {
+          statusElement.textContent = await response.text();
+        }
+      } catch {
+        // Keep the current status visible if the helper server is shutting down.
+      }
+    }
+
+    refreshStatus();
+    window.setInterval(refreshStatus, 2000);
+  </script>
+</body>
+
+</html>

--- a/tests/test_auth_status.py
+++ b/tests/test_auth_status.py
@@ -1,0 +1,38 @@
+from src.bilipod.utils.auth_status import (
+    clear_auth_status,
+    get_auth_status,
+    set_auth_status,
+)
+
+
+def test_auth_status_snapshot_contains_action():
+    clear_auth_status()
+    try:
+        set_auth_status(
+            state="action_required",
+            message="Geetest login required.",
+            action_label="Open Geetest login",
+            action_url="https://example.com/login",
+        )
+
+        status = get_auth_status()
+
+        assert status["state"] == "action_required"
+        assert status["message"] == "Geetest login required."
+        assert status["action_label"] == "Open Geetest login"
+        assert status["action_url"] == "https://example.com/login"
+        assert status["updated_at"] > 0
+    finally:
+        clear_auth_status()
+
+
+def test_auth_status_clear_resets_to_idle():
+    set_auth_status("complete", "Logged in.")
+
+    clear_auth_status()
+    status = get_auth_status()
+
+    assert status["state"] == "idle"
+    assert status["message"] == ""
+    assert status["action_label"] is None
+    assert status["action_url"] is None

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,0 +1,120 @@
+import pytest
+
+from src.bilipod.utils.config_parser import BiliPodConfig
+
+
+def test_blank_token_config_uses_login_config(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+server: {}
+storage: {}
+token:
+  bili_jct:
+  buvid3:
+  dedeuserid:
+  sessdata:
+login:
+  method: qrcode
+  geetest_login_port: 5001
+  geetest_verify_port: 5002
+  qrcode_port: 5003
+feeds: {}
+""",
+        encoding="utf-8",
+    )
+
+    config = BiliPodConfig.from_yaml(str(config_file))
+
+    assert config.token is None
+    assert config.login.method == "qrcode"
+    assert config.login.geetest_login_port == 5001
+    assert config.login.geetest_verify_port == 5002
+    assert config.login.qrcode_port == 5003
+
+
+def test_partial_token_config_raises(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+server: {}
+storage: {}
+token:
+  bili_jct: token
+login: {}
+feeds: {}
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Token config is incomplete"):
+        BiliPodConfig.from_yaml(str(config_file))
+
+
+def test_numeric_login_fields_are_loaded_as_strings(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+server: {}
+storage: {}
+token:
+login:
+  method: sms
+  username: 12345678901
+  password: 123456
+  phone_number: 12345678901
+  country_code: 86
+  geetest_login_url: https://example.com/login
+feeds: {}
+""",
+        encoding="utf-8",
+    )
+
+    config = BiliPodConfig.from_yaml(str(config_file))
+
+    assert config.login.method == "sms"
+    assert config.login.username == "12345678901"
+    assert config.login.password == "123456"
+    assert config.login.phone_number == "12345678901"
+    assert config.login.country_code == "86"
+    assert config.login.geetest_login_url == "https://example.com/login"
+
+
+def test_env_variables_are_expanded_in_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("BILIPOD_HOSTNAME", "https://example.com")
+    monkeypatch.setenv("BILIPOD_DATA_DIR", "/tmp/bilipod-data")
+    monkeypatch.setenv("BILIPOD_USERNAME", "alice")
+    monkeypatch.setenv("BILIPOD_PASSWORD", "secret")
+    monkeypatch.delenv("BILIPOD_PHONE_NUMBER", raising=False)
+    monkeypatch.delenv("BILIPOD_COUNTRY_CODE", raising=False)
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+server:
+  hostname: $env{BILIPOD_HOSTNAME}
+storage:
+  storage.local:
+    data_dir: $env{BILIPOD_DATA_DIR}/media
+token:
+login:
+  method: password
+  username: $env{BILIPOD_USERNAME}
+  password: $env{BILIPOD_PASSWORD}
+  phone_number: $env{BILIPOD_PHONE_NUMBER}
+  country_code: $env{BILIPOD_COUNTRY_CODE}
+  geetest_login_url: $env{BILIPOD_HOSTNAME}/login
+feeds: {}
+""",
+        encoding="utf-8",
+    )
+
+    config = BiliPodConfig.from_yaml(str(config_file))
+
+    assert config.server.hostname == "https://example.com"
+    assert config.storage.data_dir == "/tmp/bilipod-data/media"
+    assert config.login.username == "alice"
+    assert config.login.password == "secret"
+    assert config.login.phone_number is None
+    assert config.login.country_code == "+86"
+    assert config.login.geetest_login_url == "https://example.com/login"

--- a/tests/test_login_helpers.py
+++ b/tests/test_login_helpers.py
@@ -1,0 +1,159 @@
+import asyncio
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from src.bilipod.utils.login import (
+    QRCodeLoginServer,
+    SMSCodeServer,
+    _format_public_url,
+    _normalize_login_method,
+    _path_prefix_from_url,
+    _render_qrcode_login_page,
+    _render_sms_code_page,
+    _strip_path_prefix,
+)
+
+
+def test_login_method_aliases():
+    assert _normalize_login_method("password") == "pwd"
+    assert _normalize_login_method("sms") == "sms"
+    assert _normalize_login_method("qr") == "qrcode"
+    assert _normalize_login_method("") is None
+
+
+def test_public_url_defaults_to_loopback_for_wildcard_bind():
+    assert _format_public_url(None, "0.0.0.0", 41942) == "http://127.0.0.1:41942/"
+
+
+def test_public_url_uses_explicit_configured_url():
+    assert _format_public_url("https://example.com/login", "0.0.0.0", 41942) == (
+        "https://example.com/login/"
+    )
+
+
+def test_auth_url_path_prefix_helpers():
+    assert _path_prefix_from_url("https://example.com/bilipod/geetest-login/") == (
+        "/bilipod/geetest-login"
+    )
+    assert _strip_path_prefix(
+        "/bilipod/geetest-login/result/validate=ok",
+        "/bilipod/geetest-login",
+    ) == "/result/validate=ok"
+    assert _strip_path_prefix("/result/validate=ok", "/bilipod/geetest-login") == (
+        "/result/validate=ok"
+    )
+
+
+def test_qrcode_login_template_rendering_escapes_values():
+    html = _render_qrcode_login_page(
+        '<img src="{{ qrcode_src }}"><p data-health-src="{{ health_src }}">{{ status }}</p>',
+        '/qrcode.png?next=<script>',
+        'Waiting for <scan>',
+        '/health?next=<script>',
+    )
+
+    assert "/qrcode.png?next=&lt;script&gt;" in html
+    assert "/health?next=&lt;script&gt;" in html
+    assert "Waiting for &lt;scan&gt;" in html
+
+
+def test_sms_code_template_rendering_escapes_values():
+    html = _render_sms_code_page(
+        (
+            '<form action="{{ form_action }}"><h1>{{ title }}</h1>'
+            '<p data-health-src="{{ health_src }}">{{ message }}</p>'
+            '<button {{ submit_button_attr }}>Submit</button></form>'
+        ),
+        'SMS <Title>',
+        'Enter <code>',
+        '/login?next=<script>',
+        health_src='/health?next=<script>',
+        submitted=True,
+    )
+
+    assert 'action="/login?next=&lt;script&gt;"' in html
+    assert 'data-health-src="/health?next=&lt;script&gt;"' in html
+    assert "SMS &lt;Title&gt;" in html
+    assert "Enter &lt;code&gt;" in html
+    assert "disabled" in html
+
+
+def test_qrcode_login_server_serves_page_image_and_health():
+    server = QRCodeLoginServer(
+        image_bytes=b"fake-png",
+        bind_address="127.0.0.1",
+        port=0,
+        status_getter=lambda: "Waiting for scan",
+        path_prefix="/login",
+    )
+
+    try:
+        server.start()
+        base_url = f"http://127.0.0.1:{server.port}/login"
+
+        with urlopen(f"{base_url}/", timeout=2) as response:
+            html = response.read().decode("utf-8")
+            assert response.status == 200
+            assert 'src="/login/qrcode.png"' in html
+            assert 'data-health-src="/login/health"' in html
+            assert 'http-equiv="refresh"' not in html
+            assert "Waiting for scan" in html
+
+        with urlopen(f"{base_url}/qrcode.png", timeout=2) as response:
+            assert response.status == 200
+            assert response.headers["Content-Type"] == "image/png"
+            assert response.read() == b"fake-png"
+
+        with urlopen(f"{base_url}/health", timeout=2) as response:
+            assert response.status == 200
+            assert response.read().decode("utf-8") == "Waiting for scan"
+    finally:
+        server.stop()
+
+
+def test_sms_code_server_serves_form_and_receives_code():
+    server = SMSCodeServer(
+        bind_address="127.0.0.1",
+        port=0,
+        path_prefix="/verify",
+        title="Security Verification",
+    )
+
+    try:
+        server.start()
+        base_url = f"http://127.0.0.1:{server.port}/verify"
+
+        with urlopen(f"{base_url}/", timeout=2) as response:
+            html = response.read().decode("utf-8")
+            assert response.status == 200
+            assert 'action="/verify/"' in html
+            assert 'data-health-src="/verify/health"' in html
+            assert "Security Verification" in html
+
+        body = urlencode({"code": "312225"}).encode("utf-8")
+        request = Request(
+            f"{base_url}/",
+            data=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            method="POST",
+        )
+        with urlopen(request, timeout=2) as response:
+            html = response.read().decode("utf-8")
+            assert response.status == 200
+            assert "SMS code received" in html
+
+        with urlopen(f"{base_url}/health", timeout=2) as response:
+            assert response.status == 200
+            assert (
+                response.read().decode("utf-8")
+                == "SMS code received. Verifying with Bilibili."
+            )
+
+        assert asyncio.run(server.wait_for_code()) == "312225"
+
+        server.set_status("Login successful.", submitted=True)
+        with urlopen(f"{base_url}/health", timeout=2) as response:
+            assert response.status == 200
+            assert response.read().decode("utf-8") == "Login successful."
+    finally:
+        server.stop()

--- a/tests/test_opml.py
+++ b/tests/test_opml.py
@@ -1,65 +1,66 @@
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock
+from xml.etree import ElementTree as ET
 
 import pytest
 
 scr_to_src = Path(__file__).parent / "src"
 sys.path.insert(0, str(scr_to_src))
 print(sys.path)
-from src.bilipod import generate_opml
+from src.bilipod.feed import generate_opml
 
 
 @pytest.mark.parametrize(
-    "mock_pod_tbl_return_value, expected_opml_content",
+    "mock_pod_tbl_return_value",
     [
-        (
-            [
-                {
-                    "title": "Podcast 1",
-                    "keyword": "Tech",
-                    "description": "A podcast about technology.",
-                    "xml_url": "https://example.com/podcast1.xml",
-                    "opml": True,
-                },
-                {
-                    "title": "Podcast 2",
-                    "keyword": None,
-                    "description": "Another great podcast.",
-                    "xml_url": "https://example.com/podcast2.xml",
-                    "opml": True,
-                },
-                {
-                    "title": "Podcast 3",
-                    "keyword": "News",
-                    "description": "Stay informed with the latest news.",
-                    "xml_url": "https://example.com/podcast3.xml",
-                    "opml": False,
-                },
-            ],
-            '<?xml version="1.0" encoding="utf-8"?>\n'
-            "<opml version='1.0'>\n"
-            "  <head>\n"
-            "    <title>Bilipod feeds</title>\n"
-            "  </head>\n"
-            "  <body>\n"
-            "<!--\n-->\n"
-            "    <outline text='A podcast about technology.' type='rss' xmlUrl='https://example.com/podcast1.xml' title='Podcast 1[Tech]'/>\n"
-            "    \t\t<!--\n-->\n"
-            "    <outline text='Another great podcast.' type='rss' xmlUrl='https://example.com/podcast2.xml' title='Podcast 2'/>\n"
-            "    \t\t<!--\n-->\n"
-            "  </body>\n"
-            "</opml>",
-        ),
+        [
+            {
+                "title": "Podcast 1",
+                "keyword": "Tech",
+                "description": "A podcast about technology.",
+                "xml_url": "https://example.com/podcast1.xml",
+                "opml": True,
+            },
+            {
+                "title": "Podcast 2",
+                "keyword": None,
+                "description": "Another great podcast.",
+                "xml_url": "https://example.com/podcast2.xml",
+                "opml": True,
+            },
+            {
+                "title": "Podcast 3",
+                "keyword": "News",
+                "description": "Stay informed with the latest news.",
+                "xml_url": "https://example.com/podcast3.xml",
+                "opml": False,
+            },
+        ],
     ],
 )
-def test_generate_opml(mock_pod_tbl_return_value, expected_opml_content):
+def test_generate_opml(mock_pod_tbl_return_value, tmp_path):
     mock_pod_tbl = MagicMock()
     mock_pod_tbl.all.return_value = mock_pod_tbl_return_value
+    output_file = tmp_path / "test.opml"
 
-    mock_file = mock_open()
-    with patch("src.bilipod.feed.open", mock_file):
-        generate_opml(mock_pod_tbl, "test.opml")
+    generate_opml(mock_pod_tbl, output_file)
+    root = ET.parse(output_file).getroot()
+    outlines = root.find("body").findall("outline")
 
-    mock_file.assert_called_once_with("test.opml", "w", encoding="utf-8")
-    mock_file().write.assert_called_once_with(expected_opml_content)
+    assert root.tag == "opml"
+    assert root.attrib["version"] == "1.0"
+    assert root.find("head/title").text == "Bilipod feeds"
+    assert len(outlines) == 2
+    assert outlines[0].attrib == {
+        "text": "A podcast about technology.",
+        "type": "rss",
+        "xmlUrl": "https://example.com/podcast1.xml",
+        "title": "Podcast 1[Tech]",
+    }
+    assert outlines[1].attrib == {
+        "text": "Another great podcast.",
+        "type": "rss",
+        "xmlUrl": "https://example.com/podcast2.xml",
+        "title": "Podcast 2",
+    }

--- a/tests/test_podcast_xml.py
+++ b/tests/test_podcast_xml.py
@@ -60,7 +60,10 @@ class TestGenerateFeedXML(unittest.TestCase):
         generate_feed_xml(self.pod, self.episode_tbl)
 
         # Check if rss_file was called correctly
-        FeedGenerator.rss_file.assert_called_with("/path/to/data/test.xml")
+        FeedGenerator.rss_file.assert_called_with(
+            filename="/path/to/data/test.xml",
+            pretty=True,
+        )
 
         # Check if the correct number of episodes were processed
         self.assertEqual(len(self.episode_data), 1)


### PR DESCRIPTION
## Summary
- add fixed-port Geetest, SMS, and QR login helper pages for Docker/reverse proxy deployments
- expose generic auth status on the hosted page with optional Nginx Basic Auth guidance
- support login config env expansion and pin bilibili-api-python to the current dev commit
- bump package version to 0.8.0

## Tests
- python -m compileall src tests
- conda run -n bilipod python -m pytest