### PR TITLE
Add dynamic feed config reload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bilipod"
-version = "0.8.0"
+version = "1.0.0"
 description = "Make bilibili user or playlist into podcast"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/bilipod/bp_class/pod.py
+++ b/src/bilipod/bp_class/pod.py
@@ -39,9 +39,9 @@ class Pod:
     """
 
     feed_id: str
+    base_url: str
     update_at: float = 0  # unix timestamp
     data_dir: Union[Path, str, None] = None
-    base_url: Optional[str] = None
     uid: Optional[int] = None
     sid: Optional[int] = None
     fid: Optional[int] = None
@@ -66,10 +66,13 @@ class Pod:
     endorse: Union[Literal["triple"], Sequence[str], None] = None
     keyword: Optional[str] = None
     episodes: Sequence[dict] = None
-    xml_url: Optional[str] = field(init=False)
+    xml_url: Optional[str] = field(default=None, init=False)
 
     @classmethod
     def from_dict(cls, data: dict):
+        if not data.get("base_url"):
+            raise ValueError("Pod base_url is required.")
+
         # Create a new instance without calling __post_init__
         obj = cls.__new__(cls)
         for field_name, field_type in cls.__annotations__.items():
@@ -77,17 +80,26 @@ class Pod:
             if isinstance(value, str) and "Path" in str(field_type):
                 value = Path(value)
             setattr(obj, field_name, value)
+        if obj.xml_url is None:
+            obj.xml_url = obj._build_xml_url()
         return obj
 
     def __post_init__(self):
-        if self.base_url is not None:
-            self.xml_url = f"{self.base_url}/{self.feed_id.replace('feed.', '', 1)}.xml"
+        if not self.base_url:
+            raise ValueError("Pod base_url is required.")
+
+        self.xml_url = self._build_xml_url()
         if self.data_dir is not None:
             self.data_dir = Path(self.data_dir)
 
+    def _build_xml_url(self) -> str:
+        feed_name = self.feed_id.replace("feed.", "", 1)
+        return f"{self.base_url.rstrip('/')}/{feed_name}.xml"
+
     def to_dict(self) -> dict:
-        self.data_dir = str(self.data_dir)
-        return asdict(self)
+        data = asdict(self)
+        data["data_dir"] = str(self.data_dir) if self.data_dir is not None else None
+        return data
 
     def update(self, **kwargs):
         for k, v in kwargs.items():

--- a/src/bilipod/executing/__init__.py
+++ b/src/bilipod/executing/__init__.py
@@ -1,3 +1,4 @@
+from .config_watcher import schedule_pod_update, watch_feed_config_changes
 from .initialize import data_initialize
 from .scheduler import schedule_job
 from .update import update_episodes, update_pod
@@ -5,8 +6,10 @@ from .web_server import run_web_server
 
 __all__ = [
     "data_initialize",
+    "schedule_pod_update",
     "update_episodes",
     "schedule_job",
     "update_pod",
     "run_web_server",
+    "watch_feed_config_changes",
 ]

--- a/src/bilipod/executing/clean.py
+++ b/src/bilipod/executing/clean.py
@@ -32,12 +32,10 @@ def clean_untracked_episodes(
 
     for episode_info in episode_tbl.search(Query().tracking == False):  # noqa E712
         episode = Episode.from_dict(episode_info)
-        try:
+        if episode.location is not None and episode.location.exists():
             episode.clean()
-            episode_tbl.update({"status": "deleted"}, query_episode(episode))
-        except FileNotFoundError as e:
-            logger.debug(f"{episode.location} not found", e)
-            episode_tbl.update({"status": "deleted"}, query_episode(episode))
+            logger.debug(f"Deleted untracked episode: {episode.location}")
+        episode_tbl.remove(query_episode(episode))
 
     logger.debug("Cleaned untracked episodes.")
 

--- a/src/bilipod/executing/config_watcher.py
+++ b/src/bilipod/executing/config_watcher.py
@@ -1,0 +1,141 @@
+import asyncio
+from pathlib import Path
+from typing import Dict
+
+from bilibili_api import Credential
+from tinydb import Query, table
+
+from ..bp_class import Pod
+from ..feed import generate_opml
+from ..utils.bp_log import Logger
+from ..utils.config_parser import FeedConfig, ServerConfig, load_feed_configs
+from .clean import clean_untracked_episodes, clean_unused_rss
+from .initialize import initialize_or_update_feed
+from .scheduler import clear_feed_job, feed_job_tag, schedule_job
+from .update import update_pod
+
+logger = Logger().get_logger()
+FEED_CONFIG_WATCH_INTERVAL = 30
+
+
+def feed_config_snapshot(feeds: Dict[str, FeedConfig]) -> dict:
+    return {feed_id: feed.to_dict() for feed_id, feed in feeds.items()}
+
+
+def _format_feed_ids(feed_ids: list[str]) -> str:
+    return ", ".join(feed_ids) if feed_ids else "none"
+
+
+def schedule_pod_update(pod: Pod, pod_tbl: table.Table, credential: Credential):
+    return schedule_job(
+        update_interval=pod.update_period,
+        job=update_pod,
+        pod=pod,
+        pod_tbl=pod_tbl,
+        credential=credential,
+        tags=feed_job_tag(pod.feed_id),
+    )
+
+
+async def sync_feed_config(
+    config_path: str | Path,
+    server_config: ServerConfig,
+    data_dir: str | Path,
+    pod_tbl: table.Table,
+    episode_tbl: table.Table,
+    credential: Credential,
+    current_feeds: Dict[str, FeedConfig],
+) -> Dict[str, FeedConfig]:
+    latest_feeds = load_feed_configs(str(config_path))
+    current_snapshot = feed_config_snapshot(current_feeds)
+    latest_snapshot = feed_config_snapshot(latest_feeds)
+
+    if latest_snapshot == current_snapshot:
+        return current_feeds
+
+    current_ids = set(current_snapshot)
+    latest_ids = set(latest_snapshot)
+    removed_feed_ids = sorted(current_ids - latest_ids)
+    added_feed_ids = sorted(latest_ids - current_ids)
+    updated_feed_ids = sorted(
+        feed_id
+        for feed_id in current_ids & latest_ids
+        if current_snapshot[feed_id] != latest_snapshot[feed_id]
+    )
+
+    applied_feeds = dict(current_feeds)
+    applied_added_feed_ids = []
+    applied_updated_feed_ids = []
+    changed = False
+
+    for feed_id in removed_feed_ids:
+        clear_feed_job(feed_id)
+        pod_tbl.remove(Query().feed_id == feed_id)
+        applied_feeds.pop(feed_id, None)
+        changed = True
+
+    for feed_id in added_feed_ids + updated_feed_ids:
+        try:
+            pod = await initialize_or_update_feed(
+                feed_id=feed_id,
+                feed_config=latest_feeds[feed_id],
+                server_config=server_config,
+                data_dir=data_dir,
+                pod_tbl=pod_tbl,
+                episode_tbl=episode_tbl,
+                credential=credential,
+            )
+        except Exception as e:
+            logger.exception(f"Failed to apply feed config for {feed_id}: {e}")
+            continue
+
+        clear_feed_job(feed_id)
+        schedule_pod_update(pod=pod, pod_tbl=pod_tbl, credential=credential)
+        applied_feeds[feed_id] = latest_feeds[feed_id]
+        if feed_id in added_feed_ids:
+            applied_added_feed_ids.append(feed_id)
+        else:
+            applied_updated_feed_ids.append(feed_id)
+        changed = True
+
+    if changed:
+        generate_opml(pod_tbl=pod_tbl, filename=Path(data_dir) / "podcast.opml")
+        clean_unused_rss(pod_tbl, data_dir)
+        clean_untracked_episodes(pod_tbl, episode_tbl)
+        logger.info(
+            "Feed config reloaded. "
+            f"added: {_format_feed_ids(applied_added_feed_ids)}, "
+            f"updated: {_format_feed_ids(applied_updated_feed_ids)}, "
+            f"removed: {_format_feed_ids(removed_feed_ids)}"
+        )
+
+    return applied_feeds
+
+
+async def watch_feed_config_changes(
+    config_path: str | Path,
+    server_config: ServerConfig,
+    data_dir: str | Path,
+    pod_tbl: table.Table,
+    episode_tbl: table.Table,
+    credential: Credential,
+    initial_feeds: Dict[str, FeedConfig],
+    interval: int = FEED_CONFIG_WATCH_INTERVAL,
+) -> None:
+    current_feeds = dict(initial_feeds)
+    logger.info(f"Watching feed config changes every {interval} seconds.")
+
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            current_feeds = await sync_feed_config(
+                config_path=config_path,
+                server_config=server_config,
+                data_dir=data_dir,
+                pod_tbl=pod_tbl,
+                episode_tbl=episode_tbl,
+                credential=credential,
+                current_feeds=current_feeds,
+            )
+        except Exception as e:
+            logger.exception(f"Failed to reload feed config: {e}")

--- a/src/bilipod/executing/initialize.py
+++ b/src/bilipod/executing/initialize.py
@@ -1,18 +1,122 @@
 import asyncio
 import time
+from pathlib import Path
 
 from bilibili_api import Credential
-from tinydb import table
+from tinydb import Query, table
 
-from ..bp_class import Pod
+from ..bp_class import Episode, Pod
 from ..downloader import download_episodes
 from ..feed import generate_feed_xml, generate_opml
 from ..utils.biliuser import get_episode_list, get_pod_info
 from ..utils.bp_log import Logger
-from ..utils.config_parser import BiliPodConfig
+from ..utils.config_parser import BiliPodConfig, FeedConfig, ServerConfig
+from ..utils.db_query import query_episode
 from .clean import clean_unused_episodes, clean_unused_rss
 
 logger = Logger().get_logger()
+
+
+def build_base_url(server_config: ServerConfig) -> str:
+    if server_config.hostname is None:
+        return (
+            f"{'https' if server_config.tls else 'http'}://"
+            f"{server_config.bind_address}:{server_config.port}"
+        )
+    return f"{server_config.hostname}/{server_config.path}"
+
+
+async def initialize_feed_pod(
+    feed_id: str,
+    feed_config: FeedConfig,
+    server_config: ServerConfig,
+    data_dir: Path | str,
+    pod_tbl: table.Table,
+    credential: Credential,
+) -> Pod:
+    logger.info(f"Initializing feed: {feed_id}...")
+    await asyncio.sleep(0.5)
+
+    pod = Pod(
+        feed_id=feed_id,
+        data_dir=data_dir,
+        base_url=build_base_url(server_config),
+        uid=feed_config.uid,
+        sid=feed_config.sid,
+        fid=feed_config.fid,
+        playlist_type=feed_config.playlist_type,
+        page_size=feed_config.page_size,
+        keyword=feed_config.keyword,
+        playlist_sort=feed_config.playlist_sort,
+    )
+    pod_info = await get_pod_info(
+        uid=feed_config.uid,
+        sid=feed_config.sid,
+        fid=feed_config.fid,
+        playlist_type=feed_config.playlist_type,
+        credential=credential,
+        page_size=feed_config.page_size,
+        keyword=pod.keyword,
+        playlist_sort=feed_config.playlist_sort,
+    )
+
+    pod.update(**pod_info)
+    pod.update(**{k: v for k, v in feed_config.to_dict().items() if v is not None})
+    pod.update_at = time.time()
+    pod_tbl.upsert(pod.to_dict(), Query().feed_id == feed_id)
+    return pod
+
+
+def _episode_needs_download(episode: Episode, episode_tbl: table.Table) -> bool:
+    matches = episode_tbl.search(query_episode(episode))
+    if not matches:
+        return True
+
+    stored_episode = Episode.from_dict(matches[0])
+    return stored_episode.status != "downloaded" or not stored_episode.exists()
+
+
+def _upsert_episodes(episode_list: list[Episode], episode_tbl: table.Table) -> None:
+    for episode in episode_list:
+        episode_tbl.upsert(episode.to_dict(), query_episode(episode))
+
+
+async def initialize_or_update_feed(
+    feed_id: str,
+    feed_config: FeedConfig,
+    server_config: ServerConfig,
+    data_dir: Path | str,
+    pod_tbl: table.Table,
+    episode_tbl: table.Table,
+    credential: Credential,
+) -> Pod:
+    pod = await initialize_feed_pod(
+        feed_id=feed_id,
+        feed_config=feed_config,
+        server_config=server_config,
+        data_dir=data_dir,
+        pod_tbl=pod_tbl,
+        credential=credential,
+    )
+
+    episode_list = list(set(get_episode_list(pod)))
+    episode_to_update = [
+        episode
+        for episode in episode_list
+        if _episode_needs_download(episode, episode_tbl)
+    ]
+
+    if episode_to_update:
+        logger.info(
+            f"Downloading {len(episode_to_update)} episodes for feed {feed_id}."
+        )
+        await download_episodes(
+            episode_to_update, credential=credential, max_attempts=10
+        )
+        _upsert_episodes(episode_to_update, episode_tbl)
+
+    generate_feed_xml(pod=pod, episode_tbl=episode_tbl)
+    return pod
 
 
 async def data_initialize(
@@ -22,44 +126,15 @@ async def data_initialize(
     credential: Credential,
 ) -> None:
 
-    # base_url
-    if config.server.hostname is None:
-        base_url = f"{'https' if config.server.tls else 'http'}://{config.server.bind_address}:{config.server.port}"
-    else:
-        base_url = f"{config.server.hostname}/{config.server.path}"
-
-    # init pod list
     for feed_id, feed_config in config.feeds.items():
-        logger.info(f"Initializing feed: {feed_id}...")
-        await asyncio.sleep(0.5)
-
-        # init pod
-        pod = Pod(
+        await initialize_feed_pod(
             feed_id=feed_id,
+            feed_config=feed_config,
+            server_config=config.server,
             data_dir=config.storage.data_dir,
-            base_url=base_url,
-            uid=feed_config.uid,
-            sid=feed_config.sid,
-            fid=feed_config.fid,
-            page_size=feed_config.page_size,
-            keyword=feed_config.keyword,
-        )
-        pod_info = await get_pod_info(
-            uid=feed_config.uid,
-            sid=feed_config.sid,
-            fid=feed_config.fid,
-            playlist_type=feed_config.playlist_type,
+            pod_tbl=pod_tbl,
             credential=credential,
-            page_size=feed_config.page_size,
-            keyword=pod.keyword,
         )
-
-        pod.update(**pod_info)
-        pod.update(
-            **{k: v for k, v in feed_config.to_dict().items() if v is not None}
-        )  # pod info from config
-        pod.update_at = time.time()
-        pod_tbl.insert(pod.to_dict())
 
     # init episode list
     episode_list = []
@@ -69,16 +144,23 @@ async def data_initialize(
         episode_list.extend(pod_episode_list)
 
     logger.info(f"Initializing download, {len(episode_list)} episodes found.")
-    await download_episodes(episode_list, credential=credential, max_attempts=10)
+    if episode_list:
+        await download_episodes(episode_list, credential=credential, max_attempts=10)
 
-    episode_tbl.insert_multiple([episode.to_dict() for episode in set(episode_list)])
+    if episode_list:
+        episode_tbl.insert_multiple(
+            [episode.to_dict() for episode in set(episode_list)]
+        )
 
     # init feed xml
     for pod_info in pod_tbl.all():
         pod = Pod.from_dict(pod_info)
         generate_feed_xml(pod=pod, episode_tbl=episode_tbl)
 
-    generate_opml(pod_tbl=pod_tbl, filename=f"{config.storage.data_dir}/podcast.opml")
+    generate_opml(
+        pod_tbl=pod_tbl,
+        filename=f"{config.storage.data_dir}/podcast.opml",
+    )
 
     clean_unused_rss(pod_tbl, config.storage.data_dir)
     clean_unused_episodes(episode_tbl, config.storage.data_dir)

--- a/src/bilipod/executing/scheduler.py
+++ b/src/bilipod/executing/scheduler.py
@@ -1,14 +1,50 @@
 import asyncio
 import re
+import threading
+from collections.abc import Iterable
 
 import schedule
 
 from ..utils.bp_log import Logger
 
 logger = Logger().get_logger()
+schedule_lock = threading.RLock()
 
 
-def schedule_job(update_interval, job=None, *args, **kwargs):
+def feed_job_tag(feed_id: str) -> str:
+    return f"feed:{feed_id}"
+
+
+def _normalize_tags(tags: str | Iterable[str] | None) -> tuple[str, ...]:
+    if tags is None:
+        return ()
+    if isinstance(tags, str):
+        return (tags,)
+    return tuple(tags)
+
+
+def _tag_job(scheduled_job, tags: str | Iterable[str] | None):
+    normalized_tags = _normalize_tags(tags)
+    if normalized_tags:
+        scheduled_job.tag(*normalized_tags)
+    return scheduled_job
+
+
+def clear_jobs(tag: str | None = None) -> None:
+    with schedule_lock:
+        schedule.clear(tag)
+
+
+def clear_feed_job(feed_id: str) -> None:
+    clear_jobs(feed_job_tag(feed_id))
+
+
+def run_pending() -> None:
+    with schedule_lock:
+        schedule.run_pending()
+
+
+def schedule_job(update_interval, job=None, *args, tags=None, **kwargs):
     """
     Schedules the job based on the provided update interval.
 
@@ -19,43 +55,54 @@ def schedule_job(update_interval, job=None, *args, **kwargs):
             - Defaults to "12h"
     """
 
-    if re.match(r"^\d{1,2}d$", update_interval):  # Days only
-        days = int(update_interval[:-1])
-        schedule.every(days).days.do(run_async, job, *args, **kwargs)
+    with schedule_lock:
+        if re.match(r"^\d{1,2}d$", update_interval):  # Days only
+            days = int(update_interval[:-1])
+            scheduled_job = schedule.every(days).days.do(
+                run_async, job, *args, **kwargs
+            )
 
-    elif re.match(r"^\d{1,2}d\d{1,2}h$", update_interval):  # Days and hours
-        days, hours = map(int, re.findall(r"\d+", update_interval))
-        schedule.every(days).days.at(f"{hours:02}:00").do(
-            run_async, job, *args, **kwargs
-        )
+        elif re.match(r"^\d{1,2}d\d{1,2}h$", update_interval):  # Days and hours
+            days, hours = map(int, re.findall(r"\d+", update_interval))
+            scheduled_job = schedule.every(days).days.at(f"{hours:02}:00").do(
+                run_async, job, *args, **kwargs
+            )
 
-    elif re.match(
-        r"^\d{1,2}d\d{1,2}h\d{1,2}m$", update_interval
-    ):  # Days, hours, minutes
-        days, hours, minutes = map(int, re.findall(r"\d+", update_interval))
-        schedule.every(days).days.at(f"{hours:02}:{minutes:02}").do(
-            run_async, job, *args, **kwargs
-        )
-    elif re.match(r"^\d{1,2}h$", update_interval):  # Hours only
-        hours = int(update_interval[:-1])
-        schedule.every(hours).hours.do(run_async, job, *args, **kwargs)
+        elif re.match(
+            r"^\d{1,2}d\d{1,2}h\d{1,2}m$", update_interval
+        ):  # Days, hours, minutes
+            days, hours, minutes = map(int, re.findall(r"\d+", update_interval))
+            scheduled_job = schedule.every(days).days.at(
+                f"{hours:02}:{minutes:02}"
+            ).do(run_async, job, *args, **kwargs)
+        elif re.match(r"^\d{1,2}h$", update_interval):  # Hours only
+            hours = int(update_interval[:-1])
+            scheduled_job = schedule.every(hours).hours.do(
+                run_async, job, *args, **kwargs
+            )
 
-    elif re.match(r"^\d{1,2}h\d{1,2}m$", update_interval):  # Hours and minutes
-        hours, minutes = map(int, re.findall(r"\d+", update_interval))
-        schedule.every(hours).hours.at(f":{minutes:02}").do(
-            run_async, job, *args, **kwargs
-        )
+        elif re.match(r"^\d{1,2}h\d{1,2}m$", update_interval):  # Hours and minutes
+            hours, minutes = map(int, re.findall(r"\d+", update_interval))
+            scheduled_job = schedule.every(hours).hours.at(f":{minutes:02}").do(
+                run_async, job, *args, **kwargs
+            )
 
-    elif re.match(r"^\d{1,2}m$", update_interval):  # Minutes only
-        minutes = int(update_interval[:-1])
-        schedule.every(minutes).minutes.do(run_async, job, *args, **kwargs)
+        elif re.match(r"^\d{1,2}m$", update_interval):  # Minutes only
+            minutes = int(update_interval[:-1])
+            scheduled_job = schedule.every(minutes).minutes.do(
+                run_async, job, *args, **kwargs
+            )
 
-    elif re.match(r"^\d{1,2}:\d{2}$", update_interval):  # Specific time of day
-        schedule.every().day.at(update_interval).do(run_async, job, *args, **kwargs)
+        elif re.match(r"^\d{1,2}:\d{2}$", update_interval):  # Specific time of day
+            scheduled_job = schedule.every().day.at(update_interval).do(
+                run_async, job, *args, **kwargs
+            )
 
-    else:
-        logger.error(f"Invalid update interval: {update_interval}")
-        raise ValueError(f"Invalid update interval format: {update_interval}")
+        else:
+            logger.error(f"Invalid update interval: {update_interval}")
+            raise ValueError(f"Invalid update interval format: {update_interval}")
+
+        return _tag_job(scheduled_job, tags)
 
 
 def run_async(job, *args, **kwargs):

--- a/src/bilipod/executing/web_server.py
+++ b/src/bilipod/executing/web_server.py
@@ -48,6 +48,7 @@ def run_web_server(server_config, data_dir: Path):
 
                     self.send_response(200)
                     self.send_header("Content-type", "text/html; charset=utf-8")
+                    self.send_header("Cache-Control", "no-store")
                     self.end_headers()
                     self.wfile.write(output.encode("utf-8"))
                 except Exception as e:
@@ -71,6 +72,7 @@ def run_web_server(server_config, data_dir: Path):
                             self.send_header(
                                 "Content-type", "application/xml; charset=utf-8"
                             )
+                            self.send_header("Cache-Control", "no-store")
                             self.end_headers()
                             self.wfile.write(f.read())
                     except Exception as e:
@@ -89,6 +91,7 @@ def run_web_server(server_config, data_dir: Path):
                             self.send_header(
                                 "Content-type", "application/xml; charset=utf-8"
                             )
+                            self.send_header("Cache-Control", "no-store")
                             self.end_headers()
                             self.wfile.write(f.read())
                     except Exception as e:

--- a/src/bilipod/feed/podcast_rss.py
+++ b/src/bilipod/feed/podcast_rss.py
@@ -3,11 +3,12 @@ Make a podcast XML feed with feedgen
 """
 
 import datetime
+import re
+from pathlib import Path
 
 import tzlocal
 from feedgen.feed import FeedGenerator
 from tinydb import table
-import re
 
 from ..bp_class import Episode, Pod
 from ..utils.biliuser import get_episode_list
@@ -20,9 +21,22 @@ logger = Logger().get_logger()
 def sanitize_for_xml(text):
     """Removes characters illegal in XML documents."""
     if not isinstance(text, str):
-        return "" 
-    sanitized = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f]', '', text)
+        return ""
+    sanitized = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", text)
     return sanitized
+
+
+def normalize_image_url(url):
+    if not isinstance(url, str):
+        return ""
+
+    image_url = url.strip()
+    if image_url.startswith("//"):
+        return f"https:{image_url}"
+    if image_url.lower().startswith("http://"):
+        return f"https://{image_url[7:]}"
+    return image_url
+
 
 def convert_timestamp_to_localtime(timestamp: int) -> str:
     local_timezone = tzlocal.get_localzone()
@@ -45,18 +59,29 @@ def generate_feed_xml(
     }
     """
     logger.debug(f"Generating feed for {pod.feed_id}")
-    
+
     fg = FeedGenerator()
     fg.load_extension("podcast", atom=False, rss=True)
-    fg.title(sanitize_for_xml(f"{pod.title}[{pod.keyword}]" if pod.keyword else pod.title))
+    fg.title(
+        sanitize_for_xml(f"{pod.title}[{pod.keyword}]" if pod.keyword else pod.title)
+    )
     if pod.description:
         fg.description(sanitize_for_xml(pod.description))
     else:
         fg.description(sanitize_for_xml(pod.title))
     fg.link({"href": sanitize_for_xml(pod.link), "rel": "alternate"})
-    fg.image(url=sanitize_for_xml(pod.cover_art), title=sanitize_for_xml(pod.title), link=sanitize_for_xml(pod.link))
+    fg.image(
+        url=sanitize_for_xml(normalize_image_url(pod.cover_art)),
+        title=sanitize_for_xml(pod.title),
+        link=sanitize_for_xml(pod.link),
+    )
 
-    fg.podcast.itunes_category(sanitize_for_xml(pod.category), [sanitize_for_xml(sub) for sub in pod.subcategories] if pod.subcategories else [])
+    fg.podcast.itunes_category(
+        sanitize_for_xml(pod.category),
+        [sanitize_for_xml(sub) for sub in pod.subcategories]
+        if pod.subcategories
+        else [],
+    )
     fg.podcast.itunes_author(sanitize_for_xml(pod.author))
 
     matched_episodes: list[Episode] = []
@@ -81,25 +106,31 @@ def generate_feed_xml(
         fe.description(sanitize_for_xml(episode.description))
         fe.guid(sanitize_for_xml(episode.bvid), permalink=False)
         fe.pubDate(pubdate)
-        fe.enclosure(url=sanitize_for_xml(episode.url), length=episode.size, type=sanitize_for_xml(episode.type))
+        fe.enclosure(
+            url=sanitize_for_xml(episode.url),
+            length=episode.size,
+            type=sanitize_for_xml(episode.type),
+        )
 
         fe.podcast.itunes_duration(episode.duration)
-        fe.podcast.itunes_image(sanitize_for_xml(episode.image))
+        fe.podcast.itunes_image(sanitize_for_xml(normalize_image_url(episode.image)))
         fe.podcast.itunes_explicit(episode.explicit)
 
     feed_name = f"{pod.feed_id.replace('feed.', '', 1)}"
 
     try:
         fg.rss_file(
-            filename=str(pod.data_dir / f"{feed_name}.xml"),
+            filename=str(Path(pod.data_dir) / f"{feed_name}.xml"),
             pretty=True,
         )
     except Exception as e:
         logger.error(f"Failed to generate feed for {pod.feed_id}: {e}")
         # print all fg attributes to debug
         logger.debug(fg.__dict__)
-        logger.debug(fg.rss_str(pretty=True))
-        logger.debug(fg.atom_str(pretty=True))
+        try:
+            logger.debug(fg.rss_str(pretty=True))
+        except Exception as debug_error:
+            logger.debug(f"Failed to render RSS debug output: {debug_error}")
         return
     else:
         logger.info(f"Generated feed for {feed_name}")

--- a/src/bilipod/main.py
+++ b/src/bilipod/main.py
@@ -6,7 +6,6 @@ import threading
 import time
 from pathlib import Path
 
-import schedule
 from bilibili_api import request_settings
 from tinydb import TinyDB
 
@@ -15,9 +14,11 @@ from .executing import (
     data_initialize,
     run_web_server,
     schedule_job,
+    schedule_pod_update,
     update_episodes,
-    update_pod,
+    watch_feed_config_changes,
 )
+from .executing.scheduler import run_pending
 from .utils.bp_log import Logger
 from .utils.config_parser import BiliPodConfig
 from .utils.login import get_credential, update_credential
@@ -43,11 +44,11 @@ def signal_handler(signum, frame):
 
 def run_scheduler():
     while True:
-        schedule.run_pending()
+        run_pending()
         time.sleep(1)
 
 
-async def run_service(config: BiliPodConfig, db_path: str):
+async def run_service(config: BiliPodConfig, db_path: str, config_path: str):
 
     request_settings.set("impersonate", "chrome131")
 
@@ -107,16 +108,22 @@ async def run_service(config: BiliPodConfig, db_path: str):
     logger.info("Starting scheduler...")
     for pod_info in pod_tbl.all():
         pod = Pod.from_dict(pod_info)
-        schedule_job(
-            update_interval=pod_info["update_period"],
-            job=update_pod,
-            pod=pod,
-            pod_tbl=pod_tbl,
-            credential=credential,
-        )
+        schedule_pod_update(pod=pod, pod_tbl=pod_tbl, credential=credential)
 
     # update token every 6 hours
     schedule_job(update_interval="6h", job=update_credential, credential=credential)
+
+    asyncio.create_task(
+        watch_feed_config_changes(
+            config_path=config_path,
+            server_config=config.server,
+            data_dir=data_dir,
+            pod_tbl=pod_tbl,
+            episode_tbl=episode_tbl,
+            credential=credential,
+            initial_feeds=config.feeds,
+        )
+    )
 
     run_scheduler_thread = threading.Thread(target=run_scheduler, daemon=True)
     run_scheduler_thread.start()
@@ -154,4 +161,4 @@ def main():
     # init logger
     Logger.setup(config=config.log)
 
-    asyncio.run(run_service(config, args.db))
+    asyncio.run(run_service(config, args.db, args.config))

--- a/src/bilipod/utils/config_parser.py
+++ b/src/bilipod/utils/config_parser.py
@@ -206,10 +206,7 @@ class BiliPodConfig:
         )
 
         # Parse and create FeedConfig for each feed
-        feeds_data = config_data.get("feeds", {})
-        feed_configs = {
-            feed_id: FeedConfig(**feed) for feed_id, feed in feeds_data.items()
-        }
+        feed_configs = parse_feed_configs(config_data)
 
         # Parse and create LogConfig if it exists
         log_data = config_data.get("log", None)
@@ -223,6 +220,20 @@ class BiliPodConfig:
             feeds=feed_configs,
             log=log_config,
         )
+
+
+def parse_feed_configs(config_data: dict) -> Dict[str, FeedConfig]:
+    feeds_data = config_data.get("feeds", {}) or {}
+    return {
+        feed_id: FeedConfig(**(feed or {})) for feed_id, feed in feeds_data.items()
+    }
+
+
+def load_feed_configs(config_file: str) -> Dict[str, FeedConfig]:
+    """Load only the feed section from a config file."""
+    with open(config_file, "r") as file:
+        config_data = _expand_env_values(yaml.safe_load(file) or {})
+    return parse_feed_configs(config_data)
 
 
 if __name__ == "__main__":

--- a/src/bilipod/web/static/index.html
+++ b/src/bilipod/web/static/index.html
@@ -131,18 +131,20 @@
 
     /* Episode images */
     .episode-image {
-      width: 100px;
-      height: 100px;
+      width: 128px;
+      aspect-ratio: 16 / 9;
+      height: auto;
       object-fit: cover;
-      border-radius: 12px;
+      border-radius: 8px;
       box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+      background: #F2F2F7;
     }
 
     .episode-image-placeholder {
-      width: 100px;
-      height: 100px;
+      width: 128px;
+      aspect-ratio: 16 / 9;
       background: linear-gradient(135deg, #F2F2F7, #E5E5EA);
-      border-radius: 12px;
+      border-radius: 8px;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -450,7 +452,7 @@
     async function loadOPMLFromURL(url) {
       try {
         // Fetch the OPML XML from the URL
-        const response = await fetch(url);
+        const response = await fetch(url, { cache: 'no-store' });
 
         if (!response.ok) {
           throw new Error(`Error loading OPML. HTTP status: ${response.status}`);
@@ -511,6 +513,53 @@
       return result;
     }
 
+    function normalizeImageUrl(url) {
+      if (!url) {
+        return '';
+      }
+      const imageUrl = url.trim();
+      if (imageUrl.startsWith('//')) {
+        return `https:${imageUrl}`;
+      }
+      if (imageUrl.toLowerCase().startsWith('http://')) {
+        return `https://${imageUrl.substring(7)}`;
+      }
+      return imageUrl;
+    }
+
+    function findDirectChildByName(parent, qualifiedName) {
+      const [prefix, localName] = qualifiedName.toLowerCase().split(':');
+      return Array.from(parent.children).find(child => {
+        const tagName = child.tagName.toLowerCase();
+        if (tagName === qualifiedName.toLowerCase()) {
+          return true;
+        }
+
+        if (localName) {
+          return child.localName?.toLowerCase() === localName &&
+            child.prefix?.toLowerCase() === prefix;
+        }
+
+        return child.localName?.toLowerCase() === prefix && !child.prefix;
+      });
+    }
+
+    function getEpisodeImageUrl(item, channel) {
+      const itemImage = findDirectChildByName(item, 'itunes:image');
+      const channelItunesImage = findDirectChildByName(channel, 'itunes:image');
+      const channelImage = findDirectChildByName(channel, 'image');
+      const channelImageUrl = channelImage ?
+        findDirectChildByName(channelImage, 'url')?.textContent :
+        '';
+
+      return normalizeImageUrl(
+        itemImage?.getAttribute('href') ||
+        channelItunesImage?.getAttribute('href') ||
+        channelImageUrl ||
+        ''
+      );
+    }
+
     /**
      * Recursively parses outline elements
      * @param {NodeList} outlines - The outline elements to parse
@@ -546,7 +595,7 @@
      */
     async function fetchEpisodesFromFeed(feedUrl) {
       try {
-        const response = await fetch(feedUrl);
+        const response = await fetch(feedUrl, { cache: 'no-store' });
 
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
@@ -606,9 +655,7 @@
           author: item.querySelector('author')?.textContent ||
             item.querySelector('itunes\\:author, author[itunes]')?.textContent || '',
           duration: item.querySelector('itunes\\:duration, duration[itunes]')?.textContent || '',
-          image: item.querySelector('itunes\\:image')?.getAttribute('href') ||
-            channel.querySelector('itunes\\:image')?.getAttribute('href') ||
-            '',
+          image: getEpisodeImageUrl(item, channel),
           enclosureUrl: item.querySelector('enclosure')?.getAttribute('url') || '',
           enclosureType: item.querySelector('enclosure')?.getAttribute('type') || '',
           enclosureLength: item.querySelector('enclosure')?.getAttribute('length') || ''
@@ -694,9 +741,11 @@
     }
 
     // UI-specific functions
+    const FEED_REFRESH_INTERVAL_MS = 60000;
     let allEpisodes = [];
     let allFeeds = []; // New global variable to store feed data
     let currentFilterFeedUrl = null; // To keep track of the currently selected feed
+    let isLoadingEpisodes = false;
 
     async function loadAuthStatus() {
       try {
@@ -754,32 +803,36 @@
     /**
      * Loads episodes and displays them in the UI
      */
-    async function loadEpisodes() {
+    async function loadEpisodes(options = {}) {
+      if (isLoadingEpisodes) {
+        return;
+      }
+      isLoadingEpisodes = true;
+
+      const showLoading = options.showLoading !== false;
       const loading = document.getElementById('loading');
       const errorMessage = document.getElementById('error-message');
       const episodesContainer = document.getElementById('episodes-container');
-      const episodeCount = document.getElementById('episode-count');
 
-      // Show loading, hide others
-      loading.classList.remove('d-none');
+      if (showLoading) {
+        loading.classList.remove('d-none');
+        episodesContainer.classList.add('d-none');
+      }
       errorMessage.classList.add('d-none');
-      episodesContainer.classList.add('d-none');
 
       try {
         // The OPML file is now served from the root by the web server
         const opmlUrl = 'podcast.opml';
         const opmlData = await loadOPMLFromURL(opmlUrl);
+        const previousFilterFeedUrl = currentFilterFeedUrl;
 
         allFeeds = extractFeedUrls(opmlData.body); // Extract all feeds
         displayFeedList(allFeeds); // Display the list of feeds
 
         allEpisodes = await getAllEpisodesSortedByDate(opmlData);
 
-        // Update episode count
-        episodeCount.textContent = `${allEpisodes.length} episodes loaded`;
-
-        // Display all episodes initially
-        displayEpisodesInUI(allEpisodes);
+        const filterStillExists = allFeeds.some(feed => feed.xmlUrl === previousFilterFeedUrl);
+        filterEpisodesByFeed(filterStillExists ? previousFilterFeedUrl : null);
 
         // Hide loading, show episodes
         loading.classList.add('d-none');
@@ -788,10 +841,13 @@
       } catch (error) {
         console.error('Error loading episodes:', error);
 
-        // Show error
-        loading.classList.add('d-none');
-        document.getElementById('error-text').textContent = error.message;
-        errorMessage.classList.remove('d-none');
+        if (showLoading || allEpisodes.length === 0) {
+          loading.classList.add('d-none');
+          document.getElementById('error-text').textContent = error.message;
+          errorMessage.classList.remove('d-none');
+        }
+      } finally {
+        isLoadingEpisodes = false;
       }
     }
 
@@ -806,18 +862,20 @@
       // Add "Show All" option
       const showAllItem = document.createElement('button');
       showAllItem.id = 'show-all-feeds-button'; // Add a unique ID
-      showAllItem.className = 'list-group-item list-group-item-action feed-list-item active';
+      showAllItem.className = `list-group-item list-group-item-action feed-list-item${currentFilterFeedUrl === null ? ' active' : ''}`;
+      showAllItem.dataset.feedUrl = '';
       showAllItem.textContent = 'All Episodes';
       showAllItem.onclick = () => filterEpisodesByFeed(null);
       feedListContainer.appendChild(showAllItem);
 
       feeds.forEach(feed => {
         const feedItem = document.createElement('div'); // Use div to contain button and link
-        feedItem.className = 'list-group-item list-group-item-action feed-list-item d-flex justify-content-between align-items-center';
+        feedItem.className = `list-group-item list-group-item-action feed-list-item d-flex justify-content-between align-items-center${currentFilterFeedUrl === feed.xmlUrl ? ' active' : ''}`;
+        feedItem.dataset.feedUrl = feed.xmlUrl;
+        feedItem.onclick = () => filterEpisodesByFeed(feed.xmlUrl);
 
         const feedTitleSpan = document.createElement('span');
         feedTitleSpan.textContent = feed.title;
-        feedTitleSpan.onclick = () => filterEpisodesByFeed(feed.xmlUrl);
         feedTitleSpan.style.cursor = 'pointer'; // Make the title clickable for filtering
         feedItem.appendChild(feedTitleSpan);
 
@@ -848,11 +906,7 @@
       if (feedUrl) {
         filteredEpisodes = allEpisodes.filter(episode => episode.feedUrl === feedUrl);
         // Set active class for the selected feed
-        const selectedFeedItem = Array.from(feedListItems).find(item => {
-          // Find the div that contains the span with the click handler
-          const span = item.querySelector('span');
-          return span && span.onclick.toString().includes(`'${feedUrl}'`);
-        });
+        const selectedFeedItem = Array.from(feedListItems).find(item => item.dataset.feedUrl === feedUrl);
         if (selectedFeedItem) {
           selectedFeedItem.classList.add('active');
         }
@@ -863,6 +917,11 @@
       }
       displayEpisodesInUI(filteredEpisodes);
       document.getElementById('episode-count').textContent = `${filteredEpisodes.length} episodes loaded`;
+    }
+
+    function startFeedPolling() {
+      loadEpisodes();
+      window.setInterval(() => loadEpisodes({ showLoading: false }), FEED_REFRESH_INTERVAL_MS);
     }
 
     /**
@@ -959,7 +1018,7 @@
                                 </div>
                                 <div class="col-auto">
                                     ${episode.image ?
-            `<img src="${episode.image}" alt="${episode.title}" class="episode-image" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+            `<img src="${episode.image}" alt="${episode.title}" class="episode-image" referrerpolicy="no-referrer" loading="lazy" decoding="async" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
                                           <div class="episode-image-placeholder" style="display: none;">
                                               <i class="bi bi-image"></i>
                                           </div>` :
@@ -1013,7 +1072,7 @@
     // Load episodes when page loads
     document.addEventListener('DOMContentLoaded', function () {
       startAuthStatusPolling();
-      loadEpisodes();
+      startFeedPolling();
     });
   </script>
 </body>

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,53 @@
+from tinydb import Query, TinyDB
+from tinydb.storages import MemoryStorage
+
+from src.bilipod.bp_class import Episode, Pod
+from src.bilipod.executing.clean import clean_untracked_episodes
+
+
+def _episode(bvid, data_dir):
+    episode = Episode(
+        bvid=bvid,
+        format="audio",
+        quality="low",
+        data_dir=data_dir,
+        base_url="http://localhost",
+    )
+    episode.status = "downloaded"
+    return episode
+
+
+def test_clean_untracked_episodes_removes_rows_and_existing_files(tmp_path):
+    media_dir = tmp_path / "media"
+    media_dir.mkdir()
+
+    tracked_episode = _episode("BVTRACKED", tmp_path)
+    untracked_existing_episode = _episode("BVDELETE", tmp_path)
+    untracked_missing_episode = _episode("BVMISSING", tmp_path)
+    untracked_existing_episode.location.write_text("audio", encoding="utf-8")
+
+    db = TinyDB(storage=MemoryStorage)
+    pod_tbl = db.table("pod")
+    episode_tbl = db.table("episode")
+    pod_tbl.insert(
+        Pod(
+            feed_id="feed.test",
+            data_dir=tmp_path,
+            base_url="http://localhost",
+            episodes=[{"bvid": tracked_episode.bvid}],
+        ).to_dict()
+    )
+    episode_tbl.insert_multiple(
+        [
+            tracked_episode.to_dict(),
+            untracked_existing_episode.to_dict(),
+            untracked_missing_episode.to_dict(),
+        ]
+    )
+
+    clean_untracked_episodes(pod_tbl, episode_tbl)
+
+    assert episode_tbl.search(Query().bvid == tracked_episode.bvid)
+    assert not episode_tbl.search(Query().bvid == untracked_existing_episode.bvid)
+    assert not episode_tbl.search(Query().bvid == untracked_missing_episode.bvid)
+    assert not untracked_existing_episode.location.exists()

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.bilipod.utils.config_parser import BiliPodConfig
+from src.bilipod.utils.config_parser import BiliPodConfig, load_feed_configs
 
 
 def test_blank_token_config_uses_login_config(tmp_path):
@@ -118,3 +118,24 @@ feeds: {}
     assert config.login.phone_number is None
     assert config.login.country_code == "+86"
     assert config.login.geetest_login_url == "https://example.com/login"
+
+
+def test_load_feed_configs_ignores_unrelated_invalid_config(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+token:
+  bili_jct: token
+feeds:
+  feed1:
+    uid: 123
+    update_period: 5m
+""",
+        encoding="utf-8",
+    )
+
+    feeds = load_feed_configs(str(config_file))
+
+    assert list(feeds) == ["feed1"]
+    assert feeds["feed1"].uid == 123
+    assert feeds["feed1"].update_period == "5m"

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -1,0 +1,120 @@
+import asyncio
+
+from tinydb import Query, TinyDB
+from tinydb.storages import MemoryStorage
+
+from src.bilipod.bp_class import Pod
+from src.bilipod.executing import config_watcher
+from src.bilipod.utils.config_parser import FeedConfig, ServerConfig
+
+
+def test_sync_feed_config_reconciles_changed_feeds(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+feeds:
+  feed_existing:
+    uid: 1
+    update_period: 2m
+  feed_added:
+    uid: 2
+    update_period: 3m
+""",
+        encoding="utf-8",
+    )
+
+    db = TinyDB(storage=MemoryStorage)
+    pod_tbl = db.table("pod")
+    episode_tbl = db.table("episode")
+    pod_tbl.insert(
+        Pod(
+            feed_id="feed_existing",
+            data_dir=tmp_path,
+            base_url="http://localhost",
+            update_period="1m",
+        ).to_dict()
+    )
+    pod_tbl.insert(
+        Pod(
+            feed_id="feed_removed",
+            data_dir=tmp_path,
+            base_url="http://localhost",
+        ).to_dict()
+    )
+
+    scheduled_feeds = []
+    cleared_feeds = []
+    regenerated_opml = []
+    cleaned_rss = []
+    cleaned_untracked = []
+
+    async def fake_initialize_or_update_feed(
+        feed_id,
+        feed_config,
+        server_config,
+        data_dir,
+        pod_tbl,
+        episode_tbl,
+        credential,
+    ):
+        pod = Pod(
+            feed_id=feed_id,
+            data_dir=data_dir,
+            base_url="http://localhost",
+            uid=feed_config.uid,
+            update_period=feed_config.update_period,
+        )
+        pod_tbl.upsert(pod.to_dict(), Query().feed_id == feed_id)
+        return pod
+
+    def fake_schedule_pod_update(pod, pod_tbl, credential):
+        scheduled_feeds.append((pod.feed_id, pod.update_period))
+
+    def fake_clear_feed_job(feed_id):
+        cleared_feeds.append(feed_id)
+
+    monkeypatch.setattr(
+        config_watcher, "initialize_or_update_feed", fake_initialize_or_update_feed
+    )
+    monkeypatch.setattr(config_watcher, "schedule_pod_update", fake_schedule_pod_update)
+    monkeypatch.setattr(config_watcher, "clear_feed_job", fake_clear_feed_job)
+    monkeypatch.setattr(
+        config_watcher,
+        "generate_opml",
+        lambda pod_tbl, filename: regenerated_opml.append(filename),
+    )
+    monkeypatch.setattr(
+        config_watcher,
+        "clean_unused_rss",
+        lambda pod_tbl, data_dir: cleaned_rss.append(data_dir),
+    )
+    monkeypatch.setattr(
+        config_watcher,
+        "clean_untracked_episodes",
+        lambda pod_tbl, episode_tbl: cleaned_untracked.append(True),
+    )
+
+    current_feeds = {
+        "feed_existing": FeedConfig(uid=1, update_period="1m"),
+        "feed_removed": FeedConfig(uid=3),
+    }
+
+    updated_feeds = asyncio.run(
+        config_watcher.sync_feed_config(
+            config_path=config_file,
+            server_config=ServerConfig(),
+            data_dir=tmp_path,
+            pod_tbl=pod_tbl,
+            episode_tbl=episode_tbl,
+            credential=None,
+            current_feeds=current_feeds,
+        )
+    )
+
+    assert sorted(updated_feeds) == ["feed_added", "feed_existing"]
+    assert not pod_tbl.search(Query().feed_id == "feed_removed")
+    assert sorted(scheduled_feeds) == [("feed_added", "3m"), ("feed_existing", "2m")]
+    assert sorted(cleared_feeds) == ["feed_added", "feed_existing", "feed_removed"]
+    assert regenerated_opml == [tmp_path / "podcast.opml"]
+    assert cleaned_rss == [tmp_path]
+    assert cleaned_untracked == [True]

--- a/tests/test_opml.py
+++ b/tests/test_opml.py
@@ -16,6 +16,8 @@ from src.bilipod.feed import generate_opml
     [
         [
             {
+                "feed_id": "feed.podcast1",
+                "base_url": "https://example.com",
                 "title": "Podcast 1",
                 "keyword": "Tech",
                 "description": "A podcast about technology.",
@@ -23,6 +25,8 @@ from src.bilipod.feed import generate_opml
                 "opml": True,
             },
             {
+                "feed_id": "feed.podcast2",
+                "base_url": "https://example.com",
                 "title": "Podcast 2",
                 "keyword": None,
                 "description": "Another great podcast.",
@@ -30,6 +34,8 @@ from src.bilipod.feed import generate_opml
                 "opml": True,
             },
             {
+                "feed_id": "feed.podcast3",
+                "base_url": "https://example.com",
                 "title": "Podcast 3",
                 "keyword": "News",
                 "description": "Stay informed with the latest news.",

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import pytest
+
+from src.bilipod.bp_class import Pod
+
+
+def test_pod_to_dict_does_not_mutate_data_dir(tmp_path):
+    pod = Pod(
+        feed_id="feed.test",
+        data_dir=tmp_path,
+        base_url="http://localhost",
+    )
+
+    data = pod.to_dict()
+
+    assert data["data_dir"] == str(tmp_path)
+    assert isinstance(pod.data_dir, Path)
+    assert pod.data_dir == tmp_path
+
+
+def test_pod_requires_base_url():
+    with pytest.raises(TypeError):
+        Pod(feed_id="feed.test")
+
+
+def test_pod_from_dict_requires_base_url():
+    with pytest.raises(ValueError, match="base_url is required"):
+        Pod.from_dict({"feed_id": "feed.test"})
+
+
+def test_pod_builds_xml_url_without_double_slash():
+    pod = Pod(feed_id="feed.test", base_url="http://localhost:7001/")
+
+    assert pod.xml_url == "http://localhost:7001/test.xml"

--- a/tests/test_podcast_xml.py
+++ b/tests/test_podcast_xml.py
@@ -9,13 +9,29 @@ from tinydb import table
 path_to_src = Path(__file__).parent / "src"
 sys.path.insert(0, str(path_to_src))
 from src.bilipod.bp_class import Pod
-from src.bilipod.feed.podcast_rss import generate_feed_xml
+from src.bilipod.feed.podcast_rss import generate_feed_xml, normalize_image_url
+
+
+def test_normalize_image_url_uses_https():
+    assert (
+        normalize_image_url(
+            "http://i1.hdslb.com/bfs/archive/c7ba81f129517e9c749277ef745682dd6a494e57.jpg"
+        )
+        == "https://i1.hdslb.com/bfs/archive/c7ba81f129517e9c749277ef745682dd6a494e57.jpg"
+    )
+    assert normalize_image_url("//i1.hdslb.com/bfs/archive/test.jpg") == (
+        "https://i1.hdslb.com/bfs/archive/test.jpg"
+    )
+    assert normalize_image_url("https://example.com/image.jpg") == (
+        "https://example.com/image.jpg"
+    )
 
 
 class TestGenerateFeedXML(unittest.TestCase):
     def setUp(self):
         self.pod = Pod(
             feed_id="feed.test",
+            base_url="http://example.com",
             description="A test podcast",
             link="http://example.com",
             cover_art="http://example.com/image.jpg",
@@ -57,6 +73,7 @@ class TestGenerateFeedXML(unittest.TestCase):
         FeedGenerator.rss_str = MagicMock(return_value="<rss></rss>")
         FeedGenerator.rss_file = MagicMock()
 
+        self.pod.to_dict()
         generate_feed_xml(self.pod, self.episode_tbl)
 
         # Check if rss_file was called correctly


### PR DESCRIPTION
## Summary
- add feed-only config hot reload and scheduler reconciliation
- refresh OPML/RSS/web UI without service restart for feed changes
- make feed pod base_url required and cleanup untracked episodes idempotent
- normalize image URLs to HTTPS and avoid cached feed/index responses
- bump version to 1.0.0

## Tests
- conda run -n bilipod python -m pytest